### PR TITLE
fix: add missing line in Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   vite:
@@ -9,6 +9,7 @@ services:
       - "5173:5173"
     volumes:
       - .:/app
+      - /app/node_modules
     working_dir: /app
     command: npm run dev
     environment:


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Changes
<!-- List key changes, ideally in bullet form. -->
- added missing line in Dockerfile to use named volume for node_modules

Without the missing line, the node_modules folder that is created with `nmp install` when the container is building is overwritten. Thus, vite doesn't exist in the container and the container can't start. 
This PR fixes the problem.

## Testing

<!-- Please delete options that are not relevant -->

- make sure you don't have any node_modules on your host / local machine
- run `docker compose up` from the `develop` branch and experience the described problems
- check out this PR's branch and run `docker compose up` and see the containers start as expected

