### PR TITLE
merge main to develop to get docker fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   vite:
@@ -9,6 +9,7 @@ services:
       - "5173:5173"
     volumes:
       - .:/app
+      - /app/node_modules
     working_dir: /app
     command: npm run dev
     environment:


### PR DESCRIPTION

## Related Issues
See issue #22 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes
- added missing line in Dockerfile to use named volume for node_modules
Without the missing line, the node_modules folder that is created with nmp install when the container is building is overwritten. Thus, vite doesn't exist in the container and the container can't start.
A PR has been made to main and now develop needs to be updated.

## Testing

-Make sure you can run the project
