### PR TITLE
feat: adding structure for main content with header and footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { NavLink } from "react-router";
 import { Tree } from "./components/Tree.tsx";
-import Layout from "./components/Layout";
+
 import { TreeContext, createTreeManagerFromModelNodes, getLayout } from "./contexts/TreeContext.ts"
 import { ModelDefinition, getModelNodes, applyLayers } from "./modules/LayeredModel.ts"
 import { baseModel } from "../examples/example-models.ts"
 import "@xyflow/react/dist/style.css";
 import "./App.css";
+import Layout from "./components/Layout/Layout";
 
 const App = () => {
   const modelDefintion: ModelDefinition = applyLayers(baseModel, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import { Tree } from "./components/Tree.tsx";
+import Layout from "./components/Layout";
 import "@xyflow/react/dist/style.css";
 import "./App.css";
 
 const App = () => {
   return (
-    <>
-      <Tree />
-    </>
+      <Layout>
+          <div className="tree-container">
+              <Tree />
+          </div>
+      </Layout>
   );
 };
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    return (
+        <div className="layout">
+            <header>
+                <h1>RDA Visualisation App</h1>
+            </header>
+            <main>
+                {children}
+            </main>
+            <footer>
+                <small>NBIS development</small>
+            </footer>
+        </div>
+    );
+};
+
+export default Layout;

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1,0 +1,20 @@
+.layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.layout header, footer {
+    background-color: #f8f8f8;
+    padding: 1rem;
+    text-align: center;
+}
+
+.layout main {
+    flex: 1;
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: stretch;
+    overflow: hidden;
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './Layout.css';
 
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -117,7 +117,7 @@ export const Tree = () => {
 
   return (
     <>
-      <div style={{ width: "100vw", height: "100vh" }}>
+      <div style={{ width: '100%', height: '100%' }}>
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/src/index.css
+++ b/src/index.css
@@ -1,23 +1,3 @@
-.layout {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-}
-
-header, footer {
-    background-color: #f8f8f8;
-    padding: 1rem;
-    text-align: center;
-}
-
-main {
-    flex: 1;
-    padding: 1rem;
-    display: flex;
-    justify-content: center;
-    align-items: stretch;
-    overflow: hidden;
-}
 .tree-container {
     width: 100%;
     flex: 1;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,28 @@
+.layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header, footer {
+    background-color: #f8f8f8;
+    padding: 1rem;
+    text-align: center;
+}
+
+main {
+    flex: 1;
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: stretch;
+    overflow: hidden;
+}
+.tree-container {
+    width: 100%;
+    flex: 1;
+    margin: 0 auto;
+    padding: 1rem;
+    box-sizing: border-box;
+    overflow: hidden;
+}


### PR DESCRIPTION
## Related Issues
This PR closes issue #31 
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Changes
<!-- List key changes, ideally in bullet form. -->
- A simple Layout component that can take children
- Added it to the app.tsx but can be moved to it's own page under pages

## Screenshot of the fix
After adding the changes to develop:
![image](https://github.com/user-attachments/assets/f3b64b43-9b4a-4284-8fff-5bdf6b5a5f04)

Before,  with a smaller tree:
![image](https://github.com/user-attachments/assets/c7ef0149-6c94-40fa-ad59-116ac2ff5e3b)

## Testing

<!-- Please delete options that are not relevant -->

- A certain branch in other repos is needed
- A rebuild is needed due to new dependencies
- Requires new configuration settings
- Instructions on how to test

## Further comments

At the moment the tree component can be moved around outside of its container, which is something I leave to fix later on since we still have other improvements made in the project.
- Follow up issue for making the documentation page link included in the header: https://github.com/NBISweden/rda-gorc-im/issues/41

## Checklist
- [x] Code builds and runs
