### PR TITLE
feat: adding subpanel with information of the node

### DIFF
--- a/src/components/GORCNodeView/GORCNodeView.css
+++ b/src/components/GORCNodeView/GORCNodeView.css
@@ -11,6 +11,11 @@
   height: 30px;
 }
 
+.gorc-node-root.selected {
+  outline: 3px solid #007bff;
+  border-radius: 4px;
+}
+
 .gorc-node-body {
   position: relative;
   width: calc(var(--gorc-node-size) * 6.7);

--- a/src/components/GORCNodeView/GORCNodeView.tsx
+++ b/src/components/GORCNodeView/GORCNodeView.tsx
@@ -3,13 +3,13 @@ import { GORCNode } from "../../modules/GORCNodes";
 import "./GORCNodeView.css";
 
 type Props = {
-  data: GORCNode;
+  data: GORCNode & { isSelected?: boolean };
 };
 
 export function GORCNodeView({ data }: Props) {
   return (
     <div
-      className="gorc-node-root"
+      className={`gorc-node-root${data.isSelected ? " selected" : ""}`}
       data-type={data.type}
       data-consideration-level={data.considerationLevel}
     >

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -12,15 +12,3 @@
   align-items: stretch;
   overflow: hidden;
 }
-
-.layout > main > .panel[data-visible="false"] {
-  width: 0;
-}
-
-.layout > main > .panel > .panel-container {
-  padding: 1rem;
-  width: var(--panel-size);
-  max-width: 100vw;
-  overflow: auto;
-  max-height: 100%;
-}

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -13,27 +13,13 @@
   overflow: hidden;
 }
 
-.layout > main > .panel {
-  --setting-panel-size: 25rem;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  background: #fff;
-  width: var(--setting-panel-size);
-  max-width: 100vw;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
-  overflow: hidden;
-  transition: width 0.1s;
-}
-
 .layout > main > .panel[data-visible="false"] {
   width: 0;
 }
 
 .layout > main > .panel > .panel-container {
   padding: 1rem;
-  width: var(--setting-panel-size);
+  width: var(--panel-size);
   max-width: 100vw;
   overflow: auto;
   max-height: 100%;

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import "./Layout.css";
 import Header from "../Header/Header";
 import { Footer } from "../Footer/Footer";
+import { PanelWrapper } from "../PanelWrapper/PanelWrapper";
 
 type Panel = {
   component: React.ReactNode;
@@ -31,12 +32,10 @@ const Layout: React.FC<Props> = ({ children, panels = {} }) => {
         {Object.keys(panels).map((panelId) => {
           const panel = panels[panelId];
           return (
-            <aside
-              key={panelId}
-              className="panel"
-              data-visible={currentPanel === panelId}
-            >
-              <div className="panel-container">{panel.component}</div>
+            <aside key={panelId}>
+              <PanelWrapper position="right" visible={currentPanel === panelId}>
+                {panel.component}
+              </PanelWrapper>
             </aside>
           );
         })}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -32,11 +32,13 @@ const Layout: React.FC<Props> = ({ children, panels = {} }) => {
         {Object.keys(panels).map((panelId) => {
           const panel = panels[panelId];
           return (
-            <aside key={panelId}>
-              <PanelWrapper position="right" visible={currentPanel === panelId}>
-                {panel.component}
-              </PanelWrapper>
-            </aside>
+            <PanelWrapper
+              key={panelId}
+              position="right"
+              visible={currentPanel === panelId}
+            >
+              {panel.component}
+            </PanelWrapper>
           );
         })}
       </main>

--- a/src/components/PanelWrapper/PanelWrapper.css
+++ b/src/components/PanelWrapper/PanelWrapper.css
@@ -7,7 +7,6 @@
   width: var(--panel-size);
   max-width: 100vw;
   box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.25);
-  padding: 1rem;
   transition: width 0.1s;
   overflow-y: auto;
   z-index: 10;
@@ -15,7 +14,6 @@
 
 .panel-wrapper[data-visible="false"] {
   width: 0;
-  padding: 0;
   overflow: hidden;
 }
 
@@ -25,4 +23,12 @@
 
 .panel-wrapper--right {
   right: 0;
+}
+
+.panel-content {
+  padding: 1rem;
+  width: var(--panel-size);
+  max-width: 100vw;
+  overflow: auto;
+  max-height: 100%;
 }

--- a/src/components/PanelWrapper/PanelWrapper.css
+++ b/src/components/PanelWrapper/PanelWrapper.css
@@ -1,10 +1,11 @@
-.side-panel {
+.panel-wrapper {
   --panel-size: 25rem;
   position: absolute;
   top: 0;
   bottom: 0;
   background: #fff;
   width: var(--panel-size);
+  max-width: 100vw;
   box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.25);
   padding: 1rem;
   transition: width 0.1s;
@@ -12,10 +13,16 @@
   z-index: 10;
 }
 
-.side-panel--left {
+.panel-wrapper[data-visible="false"] {
+  width: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.panel-wrapper--left {
   left: 0;
 }
 
-.side-panel--right {
+.panel-wrapper--right {
   right: 0;
 }

--- a/src/components/PanelWrapper/PanelWrapper.css
+++ b/src/components/PanelWrapper/PanelWrapper.css
@@ -1,0 +1,21 @@
+.side-panel {
+  --panel-size: 25rem;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: #fff;
+  width: var(--panel-size);
+  box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.25);
+  padding: 1rem;
+  transition: width 0.1s;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.side-panel--left {
+  left: 0;
+}
+
+.side-panel--right {
+  right: 0;
+}

--- a/src/components/PanelWrapper/PanelWrapper.tsx
+++ b/src/components/PanelWrapper/PanelWrapper.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import "./PanelWrapper.css";
+
+type Props = {
+  children: React.ReactNode;
+  position: "left" | "right";
+};
+
+export const PanelWrapper = ({ children, position }: Props) => (
+  <div className={`side-panel ${position}`}>{children}</div>
+);

--- a/src/components/PanelWrapper/PanelWrapper.tsx
+++ b/src/components/PanelWrapper/PanelWrapper.tsx
@@ -4,8 +4,14 @@ import "./PanelWrapper.css";
 type Props = {
   children: React.ReactNode;
   position: "left" | "right";
+  visible?: boolean;
 };
 
-export const PanelWrapper = ({ children, position }: Props) => (
-  <div className={`side-panel ${position}`}>{children}</div>
+export const PanelWrapper = ({ children, position, visible = true }: Props) => (
+  <div
+    className={`panel-wrapper panel-wrapper--${position}`}
+    data-visible={visible}
+  >
+    {children}
+  </div>
 );

--- a/src/components/PanelWrapper/PanelWrapper.tsx
+++ b/src/components/PanelWrapper/PanelWrapper.tsx
@@ -12,6 +12,6 @@ export const PanelWrapper = ({ children, position, visible = true }: Props) => (
     className={`panel-wrapper panel-wrapper--${position}`}
     data-visible={visible}
   >
-    {children}
+    <div className="panel-content">{children}</div>
   </div>
 );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -81,7 +81,7 @@ export const SettingsPanel = () => {
   const sliceIds = selectedSlices.map((s) => s.id);
 
   return (
-    <PanelWrapper position={"right"}>
+    <>
       <h2>Select repository</h2>
       <SingleSelect
         items={repositoryItems}
@@ -111,6 +111,6 @@ export const SettingsPanel = () => {
         onChange={setSliceIds}
         noItemsText="No slices available for this model"
       />
-    </PanelWrapper>
+    </>
   );
 };

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   SliceSelectionContext,
 } from "../contexts/SelectionContexts";
 import { RepositorySource } from "../modules/RepositorySource";
+import { PanelWrapper } from "./PanelWrapper/PanelWrapper";
 
 function packageToSelectItem(p: Package): SelectItem {
   return {
@@ -80,7 +81,7 @@ export const SettingsPanel = () => {
   const sliceIds = selectedSlices.map((s) => s.id);
 
   return (
-    <>
+    <PanelWrapper position={"right"}>
       <h2>Select repository</h2>
       <SingleSelect
         items={repositoryItems}
@@ -110,6 +111,6 @@ export const SettingsPanel = () => {
         onChange={setSliceIds}
         noItemsText="No slices available for this model"
       />
-    </>
+    </PanelWrapper>
   );
 };

--- a/src/components/SidePanel/SidePanel.css
+++ b/src/components/SidePanel/SidePanel.css
@@ -1,0 +1,60 @@
+.side-panel {
+  --side-panel-size: 25rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--side-panel-size);
+  height: 100%;
+  background: #fff;
+  box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.25);
+  padding: 1rem;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.side-panel-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #333;
+}
+
+.side-panel-close:hover {
+  color: #000;
+}
+
+.data-type {
+  text-transform: uppercase;
+  color: #333333;
+  font-family: sans-serif;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: sans-serif;
+  background-color: #999;
+  border-radius: 0.3rem;
+  text-transform: uppercase;
+}
+
+.badge.core {
+  background-color: #00327c;
+  color: white;
+}
+
+.badge.desirable {
+  background-color: #986129;
+  color: white;
+}
+
+.badge.optional {
+  background-color: #249b6c;
+  color: #222;
+}

--- a/src/components/SidePanel/SidePanel.css
+++ b/src/components/SidePanel/SidePanel.css
@@ -1,30 +1,22 @@
-.side-panel {
-  --side-panel-size: 25rem;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: var(--side-panel-size);
-  height: 100%;
-  background: #fff;
-  box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.25);
-  padding: 1rem;
-  overflow-y: auto;
-  z-index: 10;
-}
-
 .side-panel-close {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0;
+  right: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   border: none;
-  font-size: 1.5rem;
   cursor: pointer;
   color: #333;
+  font-size: 1.25rem;
 }
 
 .side-panel-close:hover {
   color: #000;
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .data-type {
@@ -36,25 +28,24 @@
 .badge {
   display: inline-block;
   padding: 0.25rem 0.6rem;
+  margin-left: 0.2rem;
   font-size: 0.75rem;
   font-weight: 600;
   font-family: sans-serif;
+  color: #222;
   background-color: #999;
-  border-radius: 0.3rem;
+  border-radius: 0.1rem;
   text-transform: uppercase;
 }
 
 .badge.core {
-  background-color: #00327c;
-  color: white;
+  background-color: #deebff;
 }
 
 .badge.desirable {
-  background-color: #986129;
-  color: white;
+  background-color: #f6eade;
 }
 
 .badge.optional {
-  background-color: #249b6c;
-  color: #222;
+  background-color: #dbf7ec;
 }

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -1,0 +1,41 @@
+import type { Node } from "@xyflow/react";
+import { GORCNode } from "../../modules/GORCNodes";
+import "./SidePanel.css";
+
+type Props = {
+  node: Node<GORCNode> | null;
+  onClose: () => void;
+};
+
+export const SidePanel = ({ node, onClose }: Props) => {
+  if (!node) return null;
+
+  const data = node.data;
+
+  return (
+    <div className="side-panel">
+      <button
+        className="side-panel-close"
+        onClick={onClose}
+        aria-label="Close panel"
+      >
+        ×
+      </button>
+      {data ? (
+        <>
+          <h2>{data.shortName}</h2>
+          <h3>{data.name}</h3>
+          <p className="data-type"> {data.type}</p>
+          {data.description && <p>{data.description}</p>}
+          <p>
+            <span className={`badge ${data.considerationLevel}`}>
+              {data.considerationLevel}
+            </span>
+          </p>
+        </>
+      ) : (
+        "No data available"
+      )}
+    </div>
+  );
+};

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -10,34 +10,54 @@ type Props = {
 };
 
 export const SidePanel = ({ node, onClose }: Props) => {
-  if (!node) return null;
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [displayedNode, setDisplayedNode] = React.useState<typeof node>(null);
 
-  const data = node.data;
+  React.useEffect(() => {
+    if (node) {
+      setDisplayedNode(node);
+      setIsOpen(true);
+    }
+  }, [node]);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setTimeout(() => {
+      setDisplayedNode(null);
+      onClose();
+    }, 100);
+  };
+
+  const data = displayedNode?.data;
 
   return (
-    <PanelWrapper position={"left"}>
+    <PanelWrapper position="left" visible={isOpen}>
       <button
         className="side-panel-close"
-        onClick={onClose}
+        onClick={handleClose}
         aria-label="Close panel"
       >
         ×
       </button>
-      {data ? (
-        <>
-          <h2>{data.shortName}</h2>
-          <h3>{data.name}</h3>
-          <p className="data-type"> {data.type}</p>
-          {data.description && <p>{data.description}</p>}
-          <p>
-            Consideration Level
-            <span className={`badge ${data.considerationLevel}`}>
-              {data.considerationLevel}
-            </span>
-          </p>
-        </>
+      {displayedNode ? (
+        data ? (
+          <>
+            <h2>{data.shortName}</h2>
+            <h3>{data.name}</h3>
+            <p className="data-type">{data.type}</p>
+            {data.description && <p>{data.description}</p>}
+            <p>
+              Consideration Level
+              <span className={`badge ${data.considerationLevel}`}>
+                {data.considerationLevel}
+              </span>
+            </p>
+          </>
+        ) : (
+          "No data available"
+        )
       ) : (
-        "No data available"
+        (null as React.ReactNode)
       )}
     </PanelWrapper>
   );

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -1,6 +1,8 @@
 import type { Node } from "@xyflow/react";
 import { GORCNode } from "../../modules/GORCNodes";
 import "./SidePanel.css";
+import { PanelWrapper } from "../PanelWrapper/PanelWrapper";
+import React from "react";
 
 type Props = {
   node: Node<GORCNode> | null;
@@ -13,7 +15,7 @@ export const SidePanel = ({ node, onClose }: Props) => {
   const data = node.data;
 
   return (
-    <div className="side-panel">
+    <PanelWrapper position={"left"}>
       <button
         className="side-panel-close"
         onClick={onClose}
@@ -28,6 +30,7 @@ export const SidePanel = ({ node, onClose }: Props) => {
           <p className="data-type"> {data.type}</p>
           {data.description && <p>{data.description}</p>}
           <p>
+            Consideration Level
             <span className={`badge ${data.considerationLevel}`}>
               {data.considerationLevel}
             </span>
@@ -36,6 +39,6 @@ export const SidePanel = ({ node, onClose }: Props) => {
       ) : (
         "No data available"
       )}
-    </div>
+    </PanelWrapper>
   );
 };

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -11,9 +11,15 @@ const nodeTypes = { gorc: GORCNodeView };
 
 export const Tree = () => {
   const treeManager = useTreeContext();
-  const nodes = treeManager.getNodes();
-  const edges = treeManager.getEdges();
   const [selectedNode, setSelectedNode] = useState<Node<GORCNode> | null>(null);
+  const nodes = treeManager.getNodes().map((node) => ({
+    ...node,
+    data: {
+      ...node.data,
+      isSelected: selectedNode?.id === node.id,
+    },
+  }));
+  const edges = treeManager.getEdges();
 
   const onNodeClick = useCallback((_event: unknown, node: Node<GORCNode>) => {
     setSelectedNode(node);

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -1,9 +1,11 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { ReactFlow, MiniMap, Controls, Node } from "@xyflow/react";
 import { useTreeContext } from "../contexts/TreeContext";
 import { GORCNodeView } from "./GORCNodeView/GORCNodeView";
+import { SidePanel } from "./SidePanel/SidePanel.tsx";
 
 import "@xyflow/react/dist/style.css";
+import { GORCNode } from "../modules/GORCNodes";
 
 const nodeTypes = { gorc: GORCNodeView };
 
@@ -11,10 +13,13 @@ export const Tree = () => {
   const treeManager = useTreeContext();
   const nodes = treeManager.getNodes();
   const edges = treeManager.getEdges();
+  const [selectedNode, setSelectedNode] = useState<Node<GORCNode> | null>(null);
 
-  const onNodeClick = useCallback((_event: unknown, node: Node) => {
-    console.log(node);
+  const onNodeClick = useCallback((_event: unknown, node: Node<GORCNode>) => {
+    setSelectedNode(node);
   }, []);
+
+  const closePanel = () => setSelectedNode(null);
 
   return (
     <>
@@ -31,6 +36,7 @@ export const Tree = () => {
           <MiniMap />
           <Controls />
         </ReactFlow>
+        <SidePanel node={selectedNode} onClose={closePanel} />
       </div>
     </>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 :root {
   --color-bg-light: #f9f9f9;
+  --panel-size: 25rem;
 }
 
 * {


### PR DESCRIPTION
## Related Issues
Closes #53 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Changes
- Added side panel
- Display information from the model

## Screenshot of the fix

![image](https://github.com/user-attachments/assets/0875452c-6521-45e8-8235-3c0c174ddcc2)



More examples:
![image](https://github.com/user-attachments/assets/dde098bb-38d1-4764-9fc0-23d745472f8d)

![image](https://github.com/user-attachments/assets/443fda33-b2e7-40bc-9fc8-e295ae293cae)

## Further comments
EDIT: The two panels share code by a component called PanelWrapper.
There can be more improvements to the GUI and styles of the side panel information especially after summer when we hopefully have the real repository information. The colors used for the badges are the lighter shades of the icon colors and the text is checked for good contrast. 

## Checklist
- [x] Code builds and runs

