### PR TITLE
Indicate broken repositories

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.css
+++ b/src/components/ErrorMessage/ErrorMessage.css
@@ -1,0 +1,5 @@
+.error-container {
+  align-self: center;
+  width: 25rem;
+  margin: 0 auto 0 2rem;
+}

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -5,7 +5,7 @@ export const ErrorMessage = () => {
     <div className="error-container">
       <p>Oh no!</p>
       <p>
-        We couln't fetch data from the chosen repository. <br></br> Please
+        We couldn't fetch data from the chosen repository. <br></br> Please
         choose a different one.
       </p>
     </div>

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,13 @@
+import "./ErrorMessage.css";
+
+export const ErrorMessage = () => {
+  return (
+    <div className="error-container">
+      <p>Oh no!</p>
+      <p>
+        We couln't fetch data from the chosen repository. <br></br> Please
+        choose a different one.
+      </p>
+    </div>
+  );
+};

--- a/src/components/MultiSelect/MultiSelect.css
+++ b/src/components/MultiSelect/MultiSelect.css
@@ -34,6 +34,16 @@
   display: none;
 }
 
+.select-button input:disabled + .select-label {
+  cursor: not-allowed;
+  color: #888;
+}
+
+.select-button input:disabled + .select-label > .text::after {
+  background-color: #eee;
+  border-color: #aaa;
+}
+
 .select-button input:checked + .select-label > .text::after {
   background-color: #369;
 }

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -5,6 +5,7 @@ export type SelectItem = {
   id: string;
   label: string;
   info: string;
+  failed?: boolean;
 };
 
 type SelectProps = {
@@ -21,6 +22,7 @@ type MultiSelectProps = SelectProps & {
 type SingleSelectProps = SelectProps & {
   onChange?: (id: string) => void;
   selection?: string;
+  disabled?: boolean;
 };
 
 export const MultiSelect: React.FC<MultiSelectProps> = ({
@@ -89,6 +91,7 @@ export const SingleSelect: React.FC<SingleSelectProps> = ({
             {...item}
             selected={selection === item.id}
             onChange={handleSelect}
+            disabled={item.failed}
           />
         ))
       ) : (
@@ -103,6 +106,7 @@ type SelectButtonProps = SelectItem & {
   selected: boolean;
   onChange: (id: string) => void;
   type: "radio" | "checkbox";
+  disabled?: boolean;
 };
 
 const SelectButton: React.FC<SelectButtonProps> = ({
@@ -112,6 +116,7 @@ const SelectButton: React.FC<SelectButtonProps> = ({
   id,
   selected,
   type,
+  disabled,
   onChange,
 }) => {
   const elementId = React.useId();
@@ -124,6 +129,7 @@ const SelectButton: React.FC<SelectButtonProps> = ({
         value={id}
         onChange={() => onChange(id)}
         checked={selected}
+        disabled={disabled}
       />
       <label className="select-label" htmlFor={elementId}>
         <span className="text">{label}</span>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -26,6 +26,7 @@ function repositoryToSelection(repo: RepositorySource) {
     id: repo.id,
     label: repo.info.name,
     info: repo.info.url || "Local source",
+    failed: repo.failed,
   };
 }
 
@@ -88,6 +89,7 @@ export const SettingsPanel = () => {
         onChange={setRepositoryId}
         variant="wide-info"
         noItemsText="No repositories available"
+        disabled={repository?.failed}
       />
       <h2>Select model</h2>
       <SingleSelect

--- a/src/contexts/SelectionContexts.ts
+++ b/src/contexts/SelectionContexts.ts
@@ -78,7 +78,8 @@ export function useModelSelectionManagers(
           setSelectedProfiles(resetArray);
           setSelectedSlices(resetArray);
         } catch (e) {
-          setRepository(null);
+          _repo.failed = true;
+          setRepository(_repo);
           setModels(resetArray);
           setModel(null);
           setProfiles(resetArray);
@@ -115,7 +116,8 @@ export function useModelSelectionManagers(
           setSelectedProfiles(resetArray);
           setSelectedSlices(resetArray);
         } catch (e) {
-          setRepository(null);
+          _repo.failed = true;
+          setRepository(_repo);
           setModels(resetArray);
           setModel(null);
           setProfiles(resetArray);

--- a/src/contexts/SelectionContexts.ts
+++ b/src/contexts/SelectionContexts.ts
@@ -83,7 +83,6 @@ export function useModelSelectionManagers(
           setModel(null);
           setProfiles(resetArray);
           setSlices(resetArray);
-          removeRepository(_repo);
           console.log(e);
         }
       }
@@ -121,7 +120,6 @@ export function useModelSelectionManagers(
           setModel(null);
           setProfiles(resetArray);
           setSlices(resetArray);
-          removeRepository(_repo);
           console.log(e);
         }
       }

--- a/src/modules/RepositorySource.ts
+++ b/src/modules/RepositorySource.ts
@@ -22,6 +22,7 @@ export type RepositoryRoot = RepositoryInfo & {
 export interface RepositorySource {
   id: string;
   info: RepositoryInfo;
+  failed?: boolean;
   getBaseModels(): Promise<BaseModel[]>;
   getProfiles(baseModel?: Pick<BaseModel, "id">): Promise<ModelProfile[]>;
   getThematicSlices(

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -26,8 +26,10 @@ import {
 import { useConfig } from "../../contexts/ConfigContext.ts";
 import "@xyflow/react/dist/style.css";
 import "./Home.css";
+import { ErrorMessage } from "../../components/ErrorMessage/ErrorMessage.tsx";
 
 const HomeBase = () => {
+  const [selectedRepo] = React.useContext(RepositorySelectionContext);
   return (
     <Layout
       panels={{
@@ -38,9 +40,13 @@ const HomeBase = () => {
         },
       }}
     >
-      <div className="tree-container">
-        <Tree />
-      </div>
+      {selectedRepo ? (
+        <div className="tree-container">
+          <Tree />
+        </div>
+      ) : (
+        <ErrorMessage />
+      )}
     </Layout>
   );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -40,7 +40,7 @@ const HomeBase = () => {
         },
       }}
     >
-      {selectedRepo ? (
+      {selectedRepo?.failed !== true ? (
         <div className="tree-container">
           <Tree />
         </div>


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related Issues
This PR closes #63.

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Changes
<!-- List key changes, ideally in bullet form. -->
- show error message when no data can be fetched from a repository
- disable the broken repository in the selection list 

## Screenshot of the fix
![image](https://github.com/user-attachments/assets/a2cabf52-f25b-4907-99de-7202890a5b13)
![image](https://github.com/user-attachments/assets/258f334c-9c8e-42d6-84e7-6cb88f4b8ba1)

## Testing

To test this, you will need to add a non-existing repository to your config file. 
- In `config.json` add this to the array of repositories:
```
    {
      "url": "broken-repo/root.json",
      "id": "broken-repo",
      "name": "Broken Repo"
    }
```
- Start the application and go to the home page
- Choose the repository called "Broken repository"
- The first time you choose it, you should see an error message
- Choose another repository
- Now the broken repository should be disabled in the list  

## Further comments
The repository will stay disabled as long as you stay on the Home page (you can open and close the side panel). As soon as you switch to Documentation, the repository will look available again.
This is not optimal but I think it can easily be solved in a future issue when we try to fetch all repository data on page load and cache it. I still think it's a relatively big improvement given the relatively small effort. 

## Checklist
- [x] Code builds and runs

<!-- Optional: include screenshots, links, or any other context. -->
