### PR TITLE
fix: add initial gh pages build action

### DIFF
--- a/.github/workflows/publish-gh-pages.yaml
+++ b/.github/workflows/publish-gh-pages.yaml
@@ -1,0 +1,59 @@
+name: Publish Github Pages
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      APP_RELATIVE_CSS_PATH: ../
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build example repos
+        run: npm run build-examples
+
+      - name: Build project
+        run: npm run build
+
+      - name: Add example config
+        run: cp ./config.example.json ./dist/config.json
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,16 @@
+{
+  "title": "Development Demo for GORC IM",
+  "useHashRouter": true,
+  "repositories": [
+    {
+      "url": "repos/example-repo/root.json",
+      "id": "example-repo",
+      "name": "Example Repo"
+    },
+    {
+      "url": "https://raw.githubusercontent.com/pdmnyberg/gorc-example-repo/refs/heads/main/gorc-and-oss/root.json",
+      "id": "gorc-and-oss",
+      "name": "GORC and OSS"
+    }
+  ]
+}

--- a/examples/export-model.ts
+++ b/examples/export-model.ts
@@ -1,12 +1,14 @@
 import {models, profiles, slices} from "./example-models";
-import {Package} from "../src/modules/LayeredModel";
+import {Package, ModelDefinition, ModelLayerDefinition} from "../src/modules/LayeredModel";
 import {RepositoryRoot} from "../src/modules/RepositorySource";
 import {ErrorGroup, chain, validateRelations, validateModelHierarchy, validateProfile, validateThematicSlice, validateUniqueIds} from "../src/modules/Validation";
 import fs from "node:fs";
 
 function main() {
     const repoId = "example-repo";
-    const rootPath = `public/${repoId}`;
+    const urlRootPath = `repos/${repoId}`;
+    const rootPath = `public/${urlRootPath}`;
+    const relativeCssPath = process.env.APP_RELATIVE_CSS_PATH || "";
 
     const errors = [
         ErrorGroup.from(validateRelations(Object.values(models), Object.values(profiles), Object.values(slices)), "validateModel"),
@@ -26,20 +28,44 @@ function main() {
         return;
     }
 
-    exportPackages(`${rootPath}/models`, models);
-    exportPackages(`${rootPath}/profiles`, profiles);
+    exportPackages(`${rootPath}/models`, mapObject(models, (m) => updateIcons(m, relativeCssPath)));
+    exportPackages(`${rootPath}/profiles`, mapObject(profiles, (p) => updateIcons(p, relativeCssPath)));
     exportPackages(`${rootPath}/slices`, slices);
     const repoRoot: RepositoryRoot = {
         id: repoId,
         name: "Example Repo",
         description: "This is an example repo",
-        url: `${repoId}/root.json`,
-        baseModels: Object.values(models).map(m => ({ref: `${repoId}/models/${m.id}.json`})),
-        profiles: Object.values(profiles).map(p => ({ref: `${repoId}/profiles/${p.id}.json`, modelId: p.modelId})),
-        thematicSlices: Object.values(slices).map(s => ({ref: `${repoId}/slices/${s.id}.json`, modelId: s.modelId})),
+        url: `${urlRootPath}/root.json`,
+        baseModels: Object.values(models).map(m => ({ref: `${urlRootPath}/models/${m.id}.json`})),
+        profiles: Object.values(profiles).map(p => ({ref: `${urlRootPath}/profiles/${p.id}.json`, modelId: p.modelId})),
+        thematicSlices: Object.values(slices).map(s => ({ref: `${urlRootPath}/slices/${s.id}.json`, modelId: s.modelId})),
     }
     fs.mkdirSync(rootPath, {recursive: true});
     fs.writeFileSync(`${rootPath}/root.json`, JSON.stringify(repoRoot));
+}
+
+function updateIcons<T extends ModelDefinition | ModelLayerDefinition>(model: T, relativeCssPath: string = ""): T {
+    return {
+        ...model,
+        nodes: model.nodes.map(node => {
+            if (node.icon) {
+                return {
+                    ...node,
+                    icon: `${relativeCssPath}${node.icon}`
+                }
+            } else {
+                return node
+            }
+        })
+    }
+}
+
+function mapObject<T, OT>(item: Record<string, T>, func: (v: T) => OT): Record<string, OT> {
+    return Object.keys(item).reduce<Record<string, OT>>((acc, key) => {
+        const value = item[key]
+        acc[key] = func(value);
+        return acc;
+    }, {})
 }
 
 function exportPackages<T extends Package>(rootPath: string, packages: {[x: string]: T}) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router";
+import { HashRouter, BrowserRouter, Routes, Route } from "react-router";
 import React from "react";
 import "./index.css";
 import Home from "./pages/Home/Home.tsx";
@@ -27,14 +27,19 @@ export const App = () => {
     });
   }, [setConfig, loadConfig]);
 
+  const routes = (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="documentation" element={<Documentation />} />
+    </Routes>
+  )
   return config ? (
     <ConfigContext.Provider value={config}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="documentation" element={<Documentation />} />
-        </Routes>
-      </BrowserRouter>
+      {config.useHashRouter ? (
+        <HashRouter>{routes}</HashRouter>
+      ) : (
+        <BrowserRouter>{routes}</BrowserRouter>
+      )}
     </ConfigContext.Provider>
   ) : (
     <div className="loading-config">Loading Config</div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -12,8 +12,6 @@ import {
   SliceSelectionContext,
 } from "../contexts/SelectionContexts";
 import { RepositorySource } from "../modules/RepositorySource";
-import { PanelWrapper } from "./PanelWrapper/PanelWrapper";
-
 function packageToSelectItem(p: Package): SelectItem {
   return {
     id: p.id,

--- a/src/contexts/ConfigContext.ts
+++ b/src/contexts/ConfigContext.ts
@@ -3,6 +3,7 @@ import React from "react";
 export type AppConfig = {
   repositories: { url: string; id: string; name: string }[];
   title: string;
+  useHashRouter: boolean;
 };
 
 export const ConfigContext = React.createContext<AppConfig>(parseAppConfig());
@@ -15,6 +16,7 @@ export function parseAppConfig(data?: unknown): AppConfig {
   const defaults: AppConfig = {
     title: "RDA Visualisation App",
     repositories: [],
+    useHashRouter: false,
   };
   if (data && typeof data === "object") {
     return {
@@ -26,6 +28,9 @@ export function parseAppConfig(data?: unknown): AppConfig {
         "repositories" in data && Array.isArray(data.repositories)
           ? data.repositories.map<AppConfig["repositories"][number]>((r) => r)
           : defaults.repositories,
+      useHashRouter: "useHashRouter" in data  && typeof data.useHashRouter === "boolean"
+        ? data.useHashRouter
+        : defaults.useHashRouter,
     };
   } else {
     return defaults;

--- a/src/contexts/TreeContext.ts
+++ b/src/contexts/TreeContext.ts
@@ -2,8 +2,8 @@ import React from "react";
 import { Node, Edge, XYPosition, MarkerType } from "@xyflow/react";
 import { GORCNode, QuestionNode, NodeId } from "../modules/GORCNodes";
 
-export interface TreeManager {
-  getNodes(): Node[];
+export interface TreeManager<T extends Record<string, unknown> = GORCNode> {
+  getNodes(): Node<T>[];
   getEdges(): Edge[];
 }
 
@@ -240,13 +240,13 @@ type Layout = { [x: string]: XYPosition };
 export function createTreeManagerFromModelNodes(
   nodes: (GORCNode | QuestionNode)[],
   layout: Layout = {}
-): TreeManager {
+): TreeManager<GORCNode> {
   const useNodes = React.useMemo(
     () => nodes.filter((n): n is GORCNode => n.type !== "question"),
     [nodes]
   );
   const treeNodes = React.useMemo(
-    () => useNodes.map<Node>((n) => nodeFromGORCNode(n, layout)),
+    () => useNodes.map<Node<GORCNode>>((n) => nodeFromGORCNode(n, layout)),
     [useNodes]
   );
   const treeEdges = React.useMemo(
@@ -257,7 +257,7 @@ export function createTreeManagerFromModelNodes(
     [useNodes]
   );
 
-  return React.useMemo(
+  return React.useMemo<TreeManager<GORCNode>>(
     () => ({
       getNodes: () => treeNodes,
       getEdges: () => treeEdges,
@@ -266,7 +266,7 @@ export function createTreeManagerFromModelNodes(
   );
 }
 
-function nodeFromGORCNode(node: GORCNode, layout: Layout): Node {
+function nodeFromGORCNode(node: GORCNode, layout: Layout): Node<GORCNode> {
   const position = layout[node.id] || {
     x: Math.random() * 300,
     y: Math.random() * 300,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  base: "./",
   server: {
     host: "0.0.0.0",
     port: 5173,


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related Issues
This PR closes #81 by adding a workflow that published github pages with example data

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Add github action for gh pages

## Changes

- adjust exports to allow configuration of icon source root
- clean up typing in order to allow strict build
- allow configuring hash router in order to work with gh pages
- add config.example.json used for gh pages
- adjust base in vite config

## Screenshot of the fix

<!-- Attach screenshot if relevant -->

## Testing

- merge to develop?

## Further comments

<!-- Specify questions or related information -->

## Checklist
- [x] Code builds and runs

