### PR TITLE
fix: make sure minimap renders an overview of the tree

### DIFF
--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useState } from "react";
-import { ReactFlow, MiniMap, Controls, Node } from "@xyflow/react";
+import { useCallback, useState, useEffect, useMemo } from "react";
+import {
+  ReactFlow,
+  MiniMap,
+  Controls,
+  Node,
+  useNodesState,
+} from "@xyflow/react";
 import { useTreeContext } from "../contexts/TreeContext";
 import { GORCNodeView } from "./GORCNodeView/GORCNodeView";
 import { SidePanel } from "./SidePanel/SidePanel.tsx";
@@ -12,14 +18,22 @@ const nodeTypes = { gorc: GORCNodeView };
 export const Tree = () => {
   const treeManager = useTreeContext();
   const [selectedNode, setSelectedNode] = useState<Node<GORCNode> | null>(null);
-  const nodes = treeManager.getNodes().map((node) => ({
-    ...node,
-    data: {
-      ...node.data,
-      isSelected: selectedNode?.id === node.id,
-    },
-  }));
+  const treeNodes = treeManager.getNodes();
+  const initialNodes = useMemo(() => {
+    return treeNodes.map((node) => ({
+      ...node,
+      data: {
+        ...node.data,
+        isSelected: selectedNode?.id === node.id,
+      },
+    }));
+  }, [treeNodes, selectedNode]);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const edges = treeManager.getEdges();
+
+  useEffect(() => {
+    setNodes(initialNodes);
+  }, [initialNodes, setNodes]);
 
   const onNodeClick = useCallback((_event: unknown, node: Node<GORCNode>) => {
     setSelectedNode(node);
@@ -37,9 +51,10 @@ export const Tree = () => {
           fitView
           nodeTypes={nodeTypes}
           nodesDraggable={false}
+          onNodesChange={onNodesChange}
           minZoom={0.1}
         >
-          <MiniMap />
+          <MiniMap nodeStrokeWidth={3} />
           <Controls />
         </ReactFlow>
         <SidePanel node={selectedNode} onClose={closePanel} />


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related Issues

This PR fixes #74 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Changes
- Add `useNodesState` and `onNodesChange` in order to trigger node rendering in minimap

## Screenshot of the fix

<img width="1526" height="1280" alt="Screen Shot 2025-08-18 at 11 17 45" src="https://github.com/user-attachments/assets/d5f39956-270b-417e-bcd3-d06f84241c80" />

## Testing

- Verify that the minimap shows the content of the current tree
- Change profiles and slices and make sure the minimap stays up to date

## Further comments

<!-- Specify questions or related information -->

## Checklist
- [x] Code builds and runs
- [x] Tests have been added/updated
- [x] Documentation updated (if needed)

<!-- Optional: include screenshots, links, or any other context. -->
