### PR TITLE
fix: fixing accessibility errors found using evaluation tool

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -25,10 +25,10 @@ function Header({ panelButtons = [] }: HeaderProps) {
   const fullTitle = pageTitle ? `${config.title}: ${pageTitle}` : config.title;
   return (
     <header className="header">
-      <div className="header-title">
+      <h1 className="header-title">
         <title>{fullTitle}</title>
         {fullTitle}
-      </div>
+      </h1>
       <nav className="header-nav">
         <ul className="nav-list">
           <li>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -35,7 +35,7 @@ const HomeBase = () => {
       panels={{
         settings: {
           component: <SettingsPanel />,
-          icon: <img src={SettingIcon} />,
+          icon: <img src={SettingIcon} alt={"Gear icon"}/>,
           label: "Settings",
         },
       }}


### PR DESCRIPTION
## Type of change

- Adding h1 level to the page
- Adding alt text to image

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes
<!-- List key changes, ideally in bullet form. -->
- Feature 1 added
- Bug 2 fixed

## Screenshot of the fix
Using the [WAVE evaluation tool](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh) to see that no errors appear on the page. 
The two errors shown before: missing h1 level for page and missing alt text for image

<img width="3185" height="1879" alt="image" src="https://github.com/user-attachments/assets/d51006fd-ce70-4853-867e-5bdf48ae4898" />

## Further comments

I have not created an issue for this because it is such a small fix.

## Checklist
- [x] Code builds and runs
