### PR TITLE
Create a legend to explain the colors and shapes

### DIFF
--- a/src/components/GORCNodeView/GORCNodeView.css
+++ b/src/components/GORCNodeView/GORCNodeView.css
@@ -88,13 +88,13 @@
   font-weight: bold;
 }
 .gorc-node-root[data-consideration-level="core"] {
-  --gorc-shape-color: rgb(0, 50, 124);
+  --gorc-shape-color: var(--color-core);
 }
 .gorc-node-root[data-consideration-level="desirable"] {
-  --gorc-shape-color: rgb(152, 97, 41);
+  --gorc-shape-color: var(--color-desirable);
 }
 .gorc-node-root[data-consideration-level="optional"] {
-  --gorc-shape-color: rgb(36, 155, 108);
+  --gorc-shape-color: var(--color-optional);
 }
 
 .gorc-node-root[data-type="category"] {

--- a/src/components/Legend/GORCLegend.css
+++ b/src/components/Legend/GORCLegend.css
@@ -1,0 +1,78 @@
+.gorc-legend {
+    position: absolute;
+    bottom: 0.75rem;
+    left: calc(2.8rem + var(--legend-left-offset, 0rem));
+    z-index: 3;
+    background: white;
+    border-radius: 0.5rem;
+    box-shadow: 0 0 0.625rem var(--color-grey-shadow);
+    padding: 0.75rem 0.9rem;
+    max-width: 18rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    transition: left 0.25s ease;
+}
+
+.gorc-legend-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.gorc-legend-section {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.gorc-legend-row {
+    display: grid;
+    grid-template-columns: 1.1rem 1fr;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.gorc-legend-label { white-space: nowrap; }
+
+.gorc-legend-dot {
+    width: 0.8rem;
+    height: 0.8rem;
+    border-radius: 50%;
+    display: inline-block;
+}
+.dot-core { background-color: var(--color-core); }
+.dot-desirable { background-color: var(--color-desirable); }
+.dot-optional { background-color: var(--color-optional); }
+
+.gorc-legend-icon {
+    --gorc-shape: none;
+    width: 1rem;
+    height: 1rem;
+    background-color: #a9a9a9;
+    mask-image: var(--gorc-shape);
+    mask-mode: alpha;
+    mask-size: contain;
+    mask-position: center;
+    mask-repeat: no-repeat;
+}
+
+.icon-category {
+    --gorc-shape: url("../../img/gorc-icon_category-core.svg");
+}
+.icon-subcategory {
+    --gorc-shape: url("../../img/gorc-icon_subcategory-core.svg");
+}
+.icon-attribute {
+    --gorc-shape: url("../../img/gorc-icon_attribute-core.svg");
+}
+.icon-feature {
+    --gorc-shape: url("../../img/gorc-icon_feature-core.svg");
+}
+.icon-essential-element {
+    --gorc-shape: url("../../img/gorc-icon_essential-element-core.svg");
+}
+
+.gorc-legend hr {
+    border: none;
+    border-top: 1px solid #e5e5e5;
+    margin: 0.5rem 0 0.6rem;
+}

--- a/src/components/Legend/GORCLegend.tsx
+++ b/src/components/Legend/GORCLegend.tsx
@@ -25,6 +25,10 @@ export const GORCLegend: React.FC = () => {
 
             <div className="gorc-legend-section">
                 <div className="gorc-legend-row">
+                    <span className="gorc-legend-icon icon-essential-element" />
+                    <span className="gorc-legend-label">Essential Element</span>
+                </div>
+                <div className="gorc-legend-row">
                     <span className="gorc-legend-icon icon-category" />
                     <span className="gorc-legend-label">Category</span>
                 </div>
@@ -39,10 +43,6 @@ export const GORCLegend: React.FC = () => {
                 <div className="gorc-legend-row">
                     <span className="gorc-legend-icon icon-feature" />
                     <span className="gorc-legend-label">Feature</span>
-                </div>
-                <div className="gorc-legend-row">
-                    <span className="gorc-legend-icon icon-essential-element" />
-                    <span className="gorc-legend-label">Essential Element</span>
                 </div>
             </div>
         </aside>

--- a/src/components/Legend/GORCLegend.tsx
+++ b/src/components/Legend/GORCLegend.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import "./GORCLegend.css";
+
+export const GORCLegend: React.FC = () => {
+    return (
+        <aside className="gorc-legend" aria-label="Legend">
+            <div className="gorc-legend-title">Legend</div>
+
+            <div className="gorc-legend-section">
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-dot dot-core" />
+                    <span className="gorc-legend-label">Core</span>
+                </div>
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-dot dot-desirable" />
+                    <span className="gorc-legend-label">Desirable</span>
+                </div>
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-dot dot-optional" />
+                    <span className="gorc-legend-label">Optional</span>
+                </div>
+            </div>
+
+            <hr />
+
+            <div className="gorc-legend-section">
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-icon icon-category" />
+                    <span className="gorc-legend-label">Category</span>
+                </div>
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-icon icon-subcategory" />
+                    <span className="gorc-legend-label">Subcategory</span>
+                </div>
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-icon icon-attribute" />
+                    <span className="gorc-legend-label">Attribute</span>
+                </div>
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-icon icon-feature" />
+                    <span className="gorc-legend-label">Feature</span>
+                </div>
+                <div className="gorc-legend-row">
+                    <span className="gorc-legend-icon icon-essential-element" />
+                    <span className="gorc-legend-label">Essential Element</span>
+                </div>
+            </div>
+        </aside>
+    );
+};
+

--- a/src/components/Tree/Tree.css
+++ b/src/components/Tree/Tree.css
@@ -1,0 +1,10 @@
+.tree-stage {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    --legend-left-offset: 0rem;
+}
+
+.tree-stage.left-panel-open {
+    --legend-left-offset: var(--panel-size);
+}

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -6,12 +6,14 @@ import {
   Node,
   useNodesState,
 } from "@xyflow/react";
-import { useTreeContext } from "../contexts/TreeContext";
-import { GORCNodeView } from "./GORCNodeView/GORCNodeView";
-import { SidePanel } from "./SidePanel/SidePanel.tsx";
+import { useTreeContext } from "../../contexts/TreeContext";
+import { GORCNodeView } from "./../GORCNodeView/GORCNodeView";
+import { SidePanel } from "./../SidePanel/SidePanel.tsx";
 
 import "@xyflow/react/dist/style.css";
-import { GORCNode } from "../modules/GORCNodes";
+import { GORCNode } from "../../modules/GORCNodes";
+import { GORCLegend } from "./../Legend/GORCLegend";
+import "./Tree.css"
 
 const nodeTypes = { gorc: GORCNodeView };
 
@@ -43,7 +45,7 @@ export const Tree = () => {
 
   return (
     <>
-      <div style={{ width: "100%", height: "100%" }}>
+      <div className={`tree-stage ${selectedNode ? "left-panel-open" : ""}`}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -57,6 +59,7 @@ export const Tree = () => {
           <MiniMap nodeStrokeWidth={3} />
           <Controls />
         </ReactFlow>
+        <GORCLegend />
         <SidePanel node={selectedNode} onClose={closePanel} />
       </div>
     </>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 :root {
   --color-bg-light: #f9f9f9;
+  --color-grey-shadow: rgba(0,0,0,.12);
+  --color-core: rgb(0, 50, 124);
+  --color-optional: rgb(36, 155, 108);
+  --color-desirable:  rgb(152, 97, 41);
   --panel-size: 25rem;
 }
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,29 +1,29 @@
 import React, { useState, useEffect } from "react";
 import "./Home.css";
-import { Tree } from "./../../components/Tree.tsx";
+import { Tree } from "../../components/Tree/Tree";
 import Layout from "./../../components/Layout/Layout";
-import { SettingsPanel } from "./../../components/SettingsPanel.tsx";
+import { SettingsPanel } from "../../components/SettingsPanel";
 import SettingIcon from "./../../img/app-icon_settings.svg";
 import {
   TreeContext,
   createTreeManagerFromModelNodes,
   getD3Layout,
   TreeLayout,
-} from "./../../contexts/TreeContext.ts";
+} from "../../contexts/TreeContext";
 import {
   ModelDefinition,
   getModelNodes,
   applyLayersAndSlices,
-} from "./../../modules/LayeredModel.ts";
-import { createRepositoryManager } from "./../../contexts/RepositoryContext.ts";
-import { HttpRepositorySource } from "./../../modules/RepositorySource.ts";
+} from "../../modules/LayeredModel";
+import { createRepositoryManager } from "../../contexts/RepositoryContext";
+import { HttpRepositorySource } from "../../modules/RepositorySource";
 import {
   useModelSelectionManagers,
   RepositorySelectionContext,
   ModelSelectionContext,
   ProfileSelectionContext,
   SliceSelectionContext,
-} from "./../../contexts/SelectionContexts.ts";
+} from "../../contexts/SelectionContexts";
 import { useConfig } from "../../contexts/ConfigContext.ts";
 import "@xyflow/react/dist/style.css";
 import "./Home.css";


### PR DESCRIPTION
## Related Issues
Closes #96 . The purpose is to explain the colors and different shapes in the tree visualisation

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Changes
- Added legend on top of the tree
- Looked at the prototype in Kumu and move the legend when the side panel opens
- Added some colors used for core, desirable and optional into the index.css as common CSS variables
- Added the Tree component to a folder that also contains a CSS file

## Screenshot of the fix

<img width="1837" height="893" alt="image" src="https://github.com/user-attachments/assets/76b1d285-18b2-4497-a6b6-19c5bdcfeda7" />


## Checklist
- [x] Code builds and runs

