### PR TITLE
Improve export to be stable and include profiles

### DIFF
--- a/examples/example-models.ts
+++ b/examples/example-models.ts
@@ -4,6 +4,7 @@ export const ossModel: BaseModel = {
     version: "0.1.0",
     id: "oss-base",
     label: "OSS Base Model",
+    updatedAt: new Date().toISOString(),
     nodes: [
         // --- Essential Element: Governance ---
         {
@@ -328,6 +329,7 @@ export const dualLicenseModelProfile: ModelProfile = {
   label: "OSS Dual-License Model",
   version: "0.1.0",
   modelId: "oss-base",
+  updatedAt: new Date().toISOString(),
   nodes: [
     // =========================================================
     // --- Governance (dual-license compliance governance) ---
@@ -609,6 +611,7 @@ export const baseModel: BaseModel = {
     version: "0.1.0",
     id: "gorc-im-base",
     label: "GORC Base Model",
+    updatedAt: new Date().toISOString(),
     nodes: [
         /**
          * These are the essential elements of the base GORC model
@@ -942,6 +945,7 @@ export const onlyGoLProfile: ModelProfile = {
     version: "0.1.0",
     id: "gorc-im-only-gol",
     label: "GORC Only Governance & Leadership",
+    updatedAt: new Date().toISOString(),
     nodes: baseModel.nodes.filter(
         node => getRoot(node, baseModel.nodes) !== "governance-and-leadership"
     ).map(node => ({
@@ -955,6 +959,7 @@ export const onlySustainabilityProfile: ModelProfile = {
     version: "0.0.1",
     id: "gorc-im-only-sustainability",
     label: "GORC Only Sustainability",
+    updatedAt: new Date().toISOString(),
     nodes: baseModel.nodes.filter(
         node => getRoot(node, baseModel.nodes) !== "sustainability"
     ).map(node => ({
@@ -968,6 +973,7 @@ export const onlyRoPaAProfile: ModelProfile = {
     version: "0.0.1",
     id: "gorc-im-only-ropaa",
     label: "GORC Only Rules of Participation & Access",
+    updatedAt: new Date().toISOString(),
     nodes: baseModel.nodes.filter(
         node => getRoot(node, baseModel.nodes) !== "rules-of-participation-and-access"
     ).map(node => ({
@@ -981,6 +987,7 @@ export const onlyGoLSlice: ThematicSlice = {
     version: "0.1.0",
     id: "gorc-im-gol-slice",
     label: "GORC Governance & Leadership Slice",
+    updatedAt: new Date().toISOString(),
     nodes: baseModel.nodes.filter(
         node => getRoot(node, baseModel.nodes) === "governance-and-leadership"
     ).map(n => ({ nodeId: n.id }))
@@ -991,6 +998,7 @@ export const onlySustainabilitySlice: ThematicSlice = {
     version: "0.1.0",
     id: "gorc-im-sustainability-slice",
     label: "GORC Sustainability Slice",
+    updatedAt: new Date().toISOString(),
     nodes: baseModel.nodes.filter(
         node => getRoot(node, baseModel.nodes) === "sustainability"
     ).map(n => ({ nodeId: n.id }))
@@ -1001,6 +1009,7 @@ export const onlyRoPaASlice: ThematicSlice = {
     version: "0.1.0",
     id: "gorc-im-ropaa-slice",
     label: "GORC Rules of Participation & Access Slice",
+    updatedAt: new Date().toISOString(),
     nodes: baseModel.nodes.filter(
         node => getRoot(node, baseModel.nodes) === "rules-of-participation-and-access"
     ).map(n => ({ nodeId: n.id }))

--- a/examples/example-models.ts
+++ b/examples/example-models.ts
@@ -323,6 +323,288 @@ export const ossModel: BaseModel = {
     ]
 }
 
+export const dualLicenseModelProfile: ModelProfile = {
+  id: "oss-dual-license",
+  label: "OSS Dual-License Model",
+  version: "0.1.0",
+  modelId: "oss-base",
+  nodes: [
+    // =========================================================
+    // --- Governance (dual-license compliance governance) ---
+    // =========================================================
+    {
+      id: "ee1",
+      type: "essential-element",
+      icon: "icons/compass.png",
+      shortName: "Governance",
+      name: "Project Governance (Dual-License)",
+      description:
+        "Decision-making and oversight for both open and enterprise editions, ensuring license boundary integrity.",
+      considerationLevel: "core",
+    },
+    {
+      id: "cat1",
+      parentId: "ee1",
+      type: "category",
+      shortName: "Oversight",
+      name: "Governance and Licensing Oversight",
+      description:
+        "Structures that ensure transparent separation and coordination of open and enterprise components.",
+      considerationLevel: "core",
+    },
+    {
+      id: "attr1",
+      parentId: "cat1",
+      type: "attribute",
+      shortName: "License Policy",
+      name: "License Governance Policy",
+      description:
+        "Defines clear policies that specify which modules are open-source and which are proprietary.",
+      considerationLevel: "core",
+    },
+    {
+      id: "feat1",
+      parentId: "attr1",
+      type: "feature",
+      shortName: "License Map",
+      name: "License Mapping System",
+      description:
+        "Maintains traceability between source code modules and their applicable licenses.",
+      considerationLevel: "core",
+    },
+    {
+      id: "kpi-lic1",
+      parentId: "feat1",
+      type: "kpi",
+      shortName: "Compliance Coverage",
+      name: "License Compliance Coverage",
+      description:
+        "Percentage of code modules with verified and up-to-date license mappings.",
+      considerationLevel: "core",
+    },
+    {
+      id: "kpi-lic2",
+      parentId: "feat1",
+      type: "kpi",
+      shortName: "Violation Rate",
+      name: "License Violation Incidents",
+      description:
+        "Number of license violations detected per release cycle.",
+      considerationLevel: "optional",
+    },
+
+    // Remove unrelated base KPIs
+    { id: "kpi1", type: "nothing" },
+    { id: "kpi1b", type: "nothing" },
+
+    // =========================================================
+    // --- Community Engagement (transparent dual engagement) ---
+    // =========================================================
+    {
+      id: "ee2",
+      type: "essential-element",
+      icon: "icons/two-guys.png",
+      shortName: "Community",
+      name: "Community Engagement (Dual-License)",
+      description:
+        "How community contributors interact under dual-license conditions, ensuring clarity and inclusiveness.",
+      considerationLevel: "core",
+    },
+    {
+      id: "attr2",
+      parentId: "ee2",
+      type: "attribute",
+      shortName: "Transparency",
+      name: "Transparency of Licensing Boundaries",
+      description:
+        "How clearly the project communicates what is open-source versus enterprise-only.",
+      considerationLevel: "desirable",
+    },
+    {
+      id: "feat2",
+      parentId: "attr2",
+      type: "feature",
+      shortName: "Disclosure",
+      name: "Public License Disclosure",
+      description:
+        "Publicly accessible documentation of module-level license boundaries.",
+      considerationLevel: "core",
+    },
+    {
+      id: "kpi2",
+      parentId: "feat2",
+      type: "kpi",
+      shortName: "Transparency Index",
+      name: "License Transparency Index",
+      description:
+        "Community-rated clarity of open vs. proprietary component distinctions.",
+      considerationLevel: "optional",
+    },
+
+    // Remove onboarding-related base elements
+    { id: "kpi2b", type: "nothing" },
+    { id: "attr2b", type: "nothing" },
+    { id: "feat2b", type: "nothing" },
+
+    // =========================================================
+    // --- Sustainability (monetization and funding mix) ---
+    // =========================================================
+    {
+      id: "ee3",
+      type: "essential-element",
+      icon: "icons/money-bag.png",
+      shortName: "Sustainability",
+      name: "Project Sustainability (Dual-License)",
+      description:
+        "Ensuring long-term viability through a balanced open-source and enterprise revenue model.",
+      considerationLevel: "core",
+    },
+    {
+      id: "cat2",
+      parentId: "ee3",
+      type: "category",
+      shortName: "Monetization",
+      name: "Monetization Strategy",
+      description:
+        "How the project sustains itself financially using open-core and enterprise licensing.",
+      considerationLevel: "core",
+    },
+    {
+      id: "attr3",
+      parentId: "cat2",
+      type: "attribute",
+      shortName: "Revenue Mix",
+      name: "Revenue Composition",
+      description:
+        "Distribution of revenue sources across support, hosting, and proprietary licensing.",
+      considerationLevel: "desirable",
+    },
+    {
+      id: "feat3",
+      parentId: "attr3",
+      type: "feature",
+      shortName: "Dual Streams",
+      name: "Dual Revenue Streams",
+      description:
+        "Revenue mechanisms supporting both open community and enterprise customer bases.",
+      considerationLevel: "core",
+    },
+    {
+      id: "kpi3",
+      parentId: "feat3",
+      type: "kpi",
+      shortName: "Open/Enterprise Ratio",
+      name: "Open vs Enterprise Revenue Ratio",
+      description:
+        "Percentage of revenue derived from open vs. enterprise offerings.",
+      considerationLevel: "optional",
+    },
+
+    // Remove grants/sponsor related base data
+    { id: "subcat1", type: "nothing" },
+    { id: "attr3b", type: "nothing" },
+    { id: "kpi3b", type: "nothing" },
+
+    // =========================================================
+    // --- Interoperability (ensuring fair access) ---
+    // =========================================================
+    {
+      id: "ee4",
+      type: "essential-element",
+      icon: "icons/chain-link.png",
+      shortName: "Interop",
+      name: "Interoperability (Dual-License)",
+      description:
+        "Ensures that open and enterprise editions interoperate cleanly and respect open API commitments.",
+      considerationLevel: "core",
+    },
+    {
+      id: "cat3",
+      parentId: "ee4",
+      type: "category",
+      shortName: "Interfaces",
+      name: "Open Integration Interfaces",
+      description:
+        "Guaranteeing open access through stable, versioned APIs even when enterprise modules exist.",
+      considerationLevel: "core",
+    },
+    {
+      id: "attr4",
+      parentId: "cat3",
+      type: "attribute",
+      shortName: "API Openness",
+      name: "Public API Commitment",
+      description:
+        "Proportion of interfaces guaranteed to remain open-source accessible.",
+      considerationLevel: "core",
+    },
+    {
+      id: "kpi4",
+      parentId: "attr4",
+      type: "kpi",
+      shortName: "API Openness",
+      name: "Public API Ratio",
+      description:
+        "Percentage of APIs that remain open and stable across enterprise releases.",
+      considerationLevel: "core",
+    },
+
+    // Remove irrelevant break metrics
+    { id: "attr4b", type: "nothing" },
+    { id: "kpi4b", type: "nothing" },
+
+    // =========================================================
+    // --- Adoption (dual-edition adoption metrics) ---
+    // =========================================================
+    {
+      id: "ee5",
+      type: "essential-element",
+      icon: "icons/rocket.png",
+      shortName: "Adoption",
+      name: "Adoption and Market Reach (Dual-License)",
+      description:
+        "Tracks uptake of both open and enterprise variants to inform business and community health.",
+      considerationLevel: "core",
+    },
+    {
+      id: "cat4",
+      parentId: "ee5",
+      type: "category",
+      shortName: "Usage Segments",
+      name: "Usage Segmentation",
+      description:
+        "Understanding adoption across open-source users and enterprise customers.",
+      considerationLevel: "core",
+    },
+    {
+      id: "attr5",
+      parentId: "cat4",
+      type: "attribute",
+      shortName: "Adoption Mix",
+      name: "Adoption Composition",
+      description:
+        "Differentiation between community and enterprise adoption rates.",
+      considerationLevel: "core",
+    },
+    {
+      id: "kpi5",
+      parentId: "attr5",
+      type: "kpi",
+      shortName: "Adoption Split",
+      name: "Community vs Enterprise Adoption Ratio",
+      description:
+        "Proportion of open vs enterprise users, measured by installations or usage telemetry.",
+      considerationLevel: "core",
+    },
+
+    // Remove localization-related base nodes
+    { id: "subcat3", type: "nothing" },
+    { id: "attr5b", type: "nothing" },
+    { id: "kpi5b", type: "nothing" },
+  ],
+};
+
+
 export const baseModel: BaseModel = {
     version: "0.1.0",
     id: "gorc-im-base",
@@ -732,7 +1014,8 @@ export const models = {
 export const profiles = {
     onlyGoLProfile,
     onlySustainabilityProfile,
-    onlyRoPaAProfile
+    onlyRoPaAProfile,
+    dualLicenseModelProfile,
 }
 
 export const slices = {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -95,24 +95,12 @@ export const SettingsPanel = () => {
     model && repository
       ? () => {
           const packager = new KMPackager()
-          const kmId: string = "gorc-im";
-          const version: string = "1.0.0";
-          const organizationId: string = "rda";
-          const knowledgeModel = packager.createPackageBundleObject(
-            `Export from GORC RDA: ${repository.info.name}`,
-            packager.createKMPackages(
-              model,
-              slices,
-              selectedProfiles,
-              repository.info.name,
-              kmId,
-              version,
-              organizationId
-            ),
-            kmId,
-            version,
-            organizationId
-          );
+          const knowledgeModel = packager.createBundle(
+            model,
+            selectedSlices,
+            selectedProfiles,
+            "rda"
+          )
           const createdAt = new Date().toISOString();
           downloadData(
             JSON.stringify(knowledgeModel, undefined, "  "),

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -100,17 +100,15 @@ export const SettingsPanel = () => {
           const organizationId: string = "rda";
           const knowledgeModel = packager.createPackageBundleObject(
             `Export from GORC RDA: ${repository.info.name}`,
-            [
-              packager.createKMPackage(
-                model,
-                slices,
-                selectedProfiles,
-                repository.info.name,
-                kmId,
-                version,
-                organizationId
-              ),
-            ],
+            packager.createKMPackages(
+              model,
+              slices,
+              selectedProfiles,
+              repository.info.name,
+              kmId,
+              version,
+              organizationId
+            ),
             kmId,
             version,
             organizationId

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -104,6 +104,7 @@ export const SettingsPanel = () => {
               packager.createKMPackage(
                 model,
                 slices,
+                selectedProfiles,
                 repository.info.name,
                 kmId,
                 version,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -92,20 +92,21 @@ export const SettingsPanel = () => {
   const sliceIds = selectedSlices.map((s) => s.id);
 
   const doExport =
-    model && repository
+    model
       ? () => {
-          const packager = new KMPackager()
+          const updatedAt = model.updatedAt ? new Date(model.updatedAt) : new Date();
+          const packager = new KMPackager(updatedAt)
           const knowledgeModel = packager.createBundle(
             model,
             selectedSlices,
             selectedProfiles,
             "rda"
           )
-          const createdAt = new Date().toISOString();
+          const createdAt = updatedAt.toISOString();
           downloadData(
             JSON.stringify(knowledgeModel, undefined, "  "),
             "application/json",
-            `rda-gorc-im-${createdAt}.json`
+            `${knowledgeModel.id.replace(/:/g, "-")}-${createdAt}.json`
           );
         }
       : null;

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -12,10 +12,7 @@ import {
   SliceSelectionContext,
 } from "../contexts/SelectionContexts";
 import { RepositorySource } from "../modules/RepositorySource";
-import {
-  createKMPackage,
-  createPackageBundleObject,
-} from "../modules/DSWExport/export";
+import { KMPackager } from "../modules/DSWExport/export";
 import { Button } from "../components/Button/Button";
 
 function packageToSelectItem(p: Package): SelectItem {
@@ -97,13 +94,14 @@ export const SettingsPanel = () => {
   const doExport =
     model && repository
       ? () => {
+          const packager = new KMPackager()
           const kmId: string = "gorc-im";
           const version: string = "1.0.0";
           const organizationId: string = "rda";
-          const knowledgeModel = createPackageBundleObject(
+          const knowledgeModel = packager.createPackageBundleObject(
             `Export from GORC RDA: ${repository.info.name}`,
             [
-              createKMPackage(
+              packager.createKMPackage(
                 model,
                 slices,
                 repository.info.name,

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -5,7 +5,7 @@ import {
   Feature,
   Attribute,
 } from "../GORCNodes";
-import { ModelDefinition, ModelLayerDefinition, ThematicSlice, ModelNode, getModelNodes, Nothing } from "../LayeredModel";
+import { ModelDefinition, ModelLayerDefinition, ThematicSlice, ModelNode, getModelNodes, Nothing, ModelProfile } from "../LayeredModel";
 import { Package, PackageBundle, Event, UUID, AddChapterEvent, AddListQuestionEvent, AddItemSelectQuestionEvent, AddAnswerEvent } from "./types";
 import { v5 as uuidv5 } from "uuid";
 
@@ -33,15 +33,15 @@ export class KMPackager {
     };
   }
 
-  createKMPackage(
+  createKMPackages(
     modelDefinition: ModelDefinition,
     slices: ThematicSlice[],
-    profiles: ModelLayerDefinition[],
+    profiles: ModelProfile[],
     name: string,
     kmId: string,
     version: string,
     organizationId: string
-  ): Package {
+  ): Package[] {
     const createdAt = this.getDateStr();
     const parentUuid = "00000000-0000-0000-0000-000000000000";
     const kmUuid = this.getStableUUID(kmId);
@@ -63,42 +63,74 @@ export class KMPackager {
       parentUuid,
     )
 
-    const profileEvents = profiles.flatMap(profile => this.eventsFromProfile(
-      profile,
-      sliceTags,
-      parentUuid
-    ))
+    const profileEvents = profiles.map<{id: string, profileKmId: string, profile: ModelProfile, events: Event[]}>((profile, index, items) => {
+      const baseId = [kmId, ...items.slice(0, index + 1).map(i => i.id)].join("-wp-")
+      return {
+        id: `${organizationId}:${baseId}:${profile.version}`,
+        profileKmId: baseId,
+        profile: profile,
+        events: this.eventsFromProfile(
+          profile,
+          sliceTags,
+          kmUuid
+        )
+      }
+    }, {});
 
-    return {
-      createdAt: createdAt,
-      forkOfPackageId: null as unknown as undefined,
-      id: `${organizationId}:${kmId}:${version}`,
-      kmId: kmId,
-      license: "Apache 2.0",
-      mergeCheckpointPackageId: null as unknown as undefined,
-      metamodelVersion: 17,
-      name: name,
-      nonEditable: false,
-      organizationId: organizationId,
-      phase: "ReleasedPackagePhase",
-      previousPackageId: null as unknown as undefined,
-      description: `This is an export from the repository ${name}`,
-      readme: `This is an export from the repository ${name}`,
-      version: version,
-      events: [
-        {
-          annotations: [],
+    const mainPackageId = `${organizationId}:${kmId}:${version}`;
+    return [
+      {
+        createdAt: createdAt,
+        forkOfPackageId: null as unknown as undefined,
+        id: mainPackageId,
+        kmId: kmId,
+        license: "Apache 2.0",
+        mergeCheckpointPackageId: null as unknown as undefined,
+        metamodelVersion: 17,
+        name: name,
+        nonEditable: false,
+        organizationId: organizationId,
+        phase: "ReleasedPackagePhase",
+        previousPackageId: null as unknown as undefined,
+        description: `The base model from repository ${name}`,
+        readme: `The base model from repository ${name}`,
+        version: version,
+        events: [
+          {
+            annotations: [],
+            createdAt: createdAt,
+            entityUuid: kmUuid,
+            eventType: "AddKnowledgeModelEvent",
+            parentUuid: parentUuid,
+            uuid: this.getEventUUID(kmId),
+          },
+          ...Object.values(sliceTags).map((t) => t.event),
+          ...events,
+        ],
+      },
+      ...profileEvents.map<Package>(({id, profileKmId, profile, events}, index, items) => {
+        const forkOfPackageId = items[index - 1] ? items[index - 1].id : mainPackageId;
+        const profiles = items.slice(0, index + 1).map(i => i.profile.label).join(" and ")
+        return {
           createdAt: createdAt,
-          entityUuid: kmUuid,
-          eventType: "AddKnowledgeModelEvent",
-          parentUuid: parentUuid,
-          uuid: this.getEventUUID(kmId),
-        },
-        ...Object.values(sliceTags).map((t) => t.event),
-        ...events,
-        ...profileEvents,
-      ],
-    };
+          forkOfPackageId: forkOfPackageId,
+          id: id,
+          kmId: profileKmId,
+          license: "Apache 2.0",
+          mergeCheckpointPackageId: forkOfPackageId,
+          metamodelVersion: 17,
+          name: `${name} with profile ${profiles}`,
+          nonEditable: false,
+          organizationId: organizationId,
+          phase: "ReleasedPackagePhase",
+          previousPackageId: forkOfPackageId,
+          description: `Profile ${profiles} from repository ${name}`,
+          readme: `Profile ${profiles} from repository ${name}`,
+          version: profile.version,
+          events: events,
+        }
+      })
+    ];
   }
 
   protected eventsFromNodes(

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -41,7 +41,7 @@ export class KMPackager {
     version: string,
     organizationId: string
   ): Package {
-    const createdAt = new Date().toISOString();
+    const createdAt = this.getDateStr();
     const parentUuid = "00000000-0000-0000-0000-000000000000";
     const kmUuid = this.getStableUUID(kmId);
     const nodes = getModelNodes(modelDefintion);
@@ -172,7 +172,7 @@ export class KMPackager {
   }
 
   protected tagFromSlice(slice: ThematicSlice, parentUuid: UUID): Event {
-    const createdAt = new Date().toISOString();
+    const createdAt = this.getDateStr();
     return {
       eventType: "AddTagEvent",
       uuid: this.getEventUUID(slice.id),
@@ -195,7 +195,7 @@ export class KMPackager {
     questionUuid: UUID;
     events: Event[];
   } {
-    const createdAt = new Date().toISOString();
+    const createdAt = this.getDateStr();
 
     const question: Event = {
       annotations: [],
@@ -251,7 +251,7 @@ export class KMPackager {
   }
 
   protected eventFromRootNode(node: GORCNode, parentUuid: string): Event {
-    const createdAt = new Date().toISOString();
+    const createdAt = this.getDateStr();
     return {
       annotations: [],
       createdAt: createdAt,
@@ -286,5 +286,9 @@ export class KMPackager {
 
   protected getTick(id: string): number {
     return this._idTickers[id] = this._idTickers[id] || 0 + 1;
+  }
+
+  protected getDateStr() {
+    return new Date().toISOString()
   }
 }

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -7,253 +7,284 @@ import {
 } from "../GORCNodes";
 import { ModelDefinition, ThematicSlice, getModelNodes } from "../LayeredModel";
 import { Package, PackageBundle, Event, UUID } from "./types";
-import { v4 as uuidv4 } from "uuid";
+import { v5 as uuidv5 } from "uuid";
 
-export function createPackageBundleObject(
-  name: string,
-  packages: Package[],
-  kmId: string,
-  version: string,
-  organizationId: string
-): PackageBundle {
-  return {
-    id: `${organizationId}:${kmId}:${version}`,
-    kmId: kmId,
-    metamodelVersion: 17,
-    name: name,
-    organizationId: organizationId,
-    version: version,
-    packages: packages,
-  };
-}
 
-export function createKMPackage(
-  modelDefintion: ModelDefinition,
-  slices: ThematicSlice[],
-  name: string,
-  kmId: string,
-  version: string,
-  organizationId: string
-): Package {
-  const createdAt = new Date().toISOString();
-  const parentUuid = "00000000-0000-0000-0000-000000000000";
-  const kmUuid = uuidv4();
-  const nodes = getModelNodes(modelDefintion);
-  const mainChapterEvents = nodes
-    .filter((node): node is GORCNode => node.type !== "question")
-    .filter((node) => !("parentId" in node))
-    .reduce<Record<string, Event>>((acc, n) => {
-      acc[n.id] = eventFromRootNode(n, parentUuid);
+export class KMPackager {
+  private _idTickers: Record<string, number> = {};
+  private _namespace = uuidv5("rda-gorc-im", "00000000-0000-0000-0000-000000000000");
+  private _uuidSet = new Set<string>()
+
+  createPackageBundleObject(
+    name: string,
+    packages: Package[],
+    kmId: string,
+    version: string,
+    organizationId: string
+  ): PackageBundle {
+    return {
+      id: `${organizationId}:${kmId}:${version}`,
+      kmId: kmId,
+      metamodelVersion: 17,
+      name: name,
+      organizationId: organizationId,
+      version: version,
+      packages: packages,
+    };
+  }
+
+  createKMPackage(
+    modelDefintion: ModelDefinition,
+    slices: ThematicSlice[],
+    name: string,
+    kmId: string,
+    version: string,
+    organizationId: string
+  ): Package {
+    const createdAt = new Date().toISOString();
+    const parentUuid = "00000000-0000-0000-0000-000000000000";
+    const kmUuid = this.getStableUUID(kmId);
+    const nodes = getModelNodes(modelDefintion);
+    const mainChapterEvents = nodes
+      .filter((node): node is GORCNode => node.type !== "question")
+      .filter((node) => !("parentId" in node))
+      .reduce<Record<string, Event>>((acc, n) => {
+        acc[n.id] = this.eventFromRootNode(n, parentUuid);
+        return acc;
+      }, {});
+
+    const sliceTags = slices.reduce<
+      Record<string, { event: Event; elements: Set<string> }>
+    >((acc, slice) => {
+      acc[slice.id] = {
+        event: this.tagFromSlice(slice, kmUuid),
+        elements: new Set(slice.nodes.map((n) => n.nodeId)),
+      };
       return acc;
     }, {});
 
-  const sliceTags = slices.reduce<
-    Record<string, { event: Event; elements: Set<string> }>
-  >((acc, slice) => {
-    acc[slice.id] = {
-      event: tagFromSlice(slice, kmUuid),
-      elements: new Set(slice.nodes.map((n) => n.nodeId)),
+    const categoryQuestions = nodes
+      .filter((node): node is Category => node.type === "category")
+      .reduce<Record<string, ReturnType<typeof this.eventsFromCategoryNode>>>(
+        (acc, node) => {
+          acc[node.id] = this.eventsFromCategoryNode(
+            node,
+            mainChapterEvents[node.parentId].entityUuid,
+            Object.values(sliceTags)
+              .filter((t) => t.elements.has(node.id))
+              .map((t) => t.event.entityUuid)
+          );
+          return acc;
+        },
+        {}
+      );
+
+    const subcategoryQuestions = nodes
+      .filter((node): node is Subcategory => node.type === "subcategory")
+      .reduce<Record<string, ReturnType<typeof this.eventsFromCategoryNode>>>(
+        (acc, node) => {
+          acc[node.id] = this.eventsFromCategoryNode(
+            node,
+            categoryQuestions[node.parentId].elaborateUuid,
+            Object.values(sliceTags)
+              .filter((t) => t.elements.has(node.id))
+              .map((t) => t.event.entityUuid)
+          );
+          return acc;
+        },
+        {}
+      );
+
+    const attributeQuestions = nodes
+      .filter((node): node is Attribute => node.type === "attribute")
+      .reduce<Record<string, ReturnType<typeof this.eventsFromCategoryNode>>>(
+        (acc, node) => {
+          const parentUuid =
+            mainChapterEvents[node.parentId]?.entityUuid ||
+            categoryQuestions[node.parentId]?.elaborateUuid ||
+            subcategoryQuestions[node.parentId]?.elaborateUuid;
+          if (parentUuid) {
+            acc[node.id] = this.eventsFromCategoryNode(
+              node,
+              parentUuid,
+              Object.values(sliceTags)
+                .filter((t) => t.elements.has(node.id))
+                .map((t) => t.event.entityUuid)
+            );
+          }
+          return acc;
+        },
+        {}
+      );
+
+    const featureQuestions = nodes
+      .filter((node): node is Feature => node.type === "feature")
+      .reduce<Record<string, ReturnType<typeof this.eventsFromCategoryNode>>>(
+        (acc, node) => {
+          const parentUuid = attributeQuestions[node.parentId]?.elaborateUuid;
+          if (parentUuid) {
+            acc[node.id] = this.eventsFromCategoryNode(
+              node,
+              parentUuid,
+              Object.values(sliceTags)
+                .filter((t) => t.elements.has(node.id))
+                .map((t) => t.event.entityUuid)
+            );
+          }
+          return acc;
+        },
+        {}
+      );
+
+    return {
+      createdAt: createdAt,
+      forkOfPackageId: null as unknown as undefined,
+      id: `${organizationId}:${kmId}:${version}`,
+      kmId: kmId,
+      license: "Apache 2.0",
+      mergeCheckpointPackageId: null as unknown as undefined,
+      metamodelVersion: 17,
+      name: name,
+      nonEditable: false,
+      organizationId: organizationId,
+      phase: "ReleasedPackagePhase",
+      previousPackageId: null as unknown as undefined,
+      description: `This is an export from the repository ${name}`,
+      readme: `This is an export from the repository ${name}`,
+      version: version,
+      events: [
+        {
+          annotations: [],
+          createdAt: createdAt,
+          entityUuid: kmUuid,
+          eventType: "AddKnowledgeModelEvent",
+          parentUuid: parentUuid,
+          uuid: this.getEventUUID(kmId),
+        },
+        ...Object.values(sliceTags).map((t) => t.event),
+        ...Object.values(mainChapterEvents),
+        ...Object.values(categoryQuestions).flatMap((d) => d.events),
+        ...Object.values(subcategoryQuestions).flatMap((d) => d.events),
+        ...Object.values(attributeQuestions).flatMap((d) => d.events),
+        ...Object.values(featureQuestions).flatMap((d) => d.events),
+      ],
     };
-    return acc;
-  }, {});
+  }
 
-  const categoryQuestions = nodes
-    .filter((node): node is Category => node.type === "category")
-    .reduce<Record<string, ReturnType<typeof eventsFromCategoryNode>>>(
-      (acc, node) => {
-        acc[node.id] = eventsFromCategoryNode(
-          node,
-          mainChapterEvents[node.parentId].entityUuid,
-          Object.values(sliceTags)
-            .filter((t) => t.elements.has(node.id))
-            .map((t) => t.event.entityUuid)
-        );
-        return acc;
-      },
-      {}
-    );
+  protected tagFromSlice(slice: ThematicSlice, parentUuid: UUID): Event {
+    const createdAt = new Date().toISOString();
+    return {
+      eventType: "AddTagEvent",
+      uuid: this.getEventUUID(slice.id),
+      parentUuid: parentUuid,
+      entityUuid: this.getStableUUID(slice.id),
+      createdAt: createdAt,
+      name: slice.label,
+      description: null,
+      color: "",
+      annotations: [],
+    };
+  }
 
-  const subcategoryQuestions = nodes
-    .filter((node): node is Subcategory => node.type === "subcategory")
-    .reduce<Record<string, ReturnType<typeof eventsFromCategoryNode>>>(
-      (acc, node) => {
-        acc[node.id] = eventsFromCategoryNode(
-          node,
-          categoryQuestions[node.parentId].elaborateUuid,
-          Object.values(sliceTags)
-            .filter((t) => t.elements.has(node.id))
-            .map((t) => t.event.entityUuid)
-        );
-        return acc;
-      },
-      {}
-    );
+  protected eventsFromCategoryNode(
+    node: Category | Subcategory | Attribute | Feature,
+    parentUuid: string,
+    tags: UUID[]
+  ): {
+    elaborateUuid: UUID;
+    questionUuid: UUID;
+    events: Event[];
+  } {
+    const createdAt = new Date().toISOString();
 
-  const attributeQuestions = nodes
-    .filter((node): node is Attribute => node.type === "attribute")
-    .reduce<Record<string, ReturnType<typeof eventsFromCategoryNode>>>(
-      (acc, node) => {
-        const parentUuid =
-          mainChapterEvents[node.parentId]?.entityUuid ||
-          categoryQuestions[node.parentId]?.elaborateUuid ||
-          subcategoryQuestions[node.parentId]?.elaborateUuid;
-        if (parentUuid) {
-          acc[node.id] = eventsFromCategoryNode(
-            node,
-            parentUuid,
-            Object.values(sliceTags)
-              .filter((t) => t.elements.has(node.id))
-              .map((t) => t.event.entityUuid)
-          );
-        }
-        return acc;
-      },
-      {}
-    );
+    const question: Event = {
+      annotations: [],
+      createdAt: createdAt,
+      entityUuid: this.getStableUUID(node.id),
+      eventType: "AddQuestionEvent",
+      parentUuid: parentUuid,
+      questionType: "OptionsQuestion",
+      requiredPhaseUuid: null,
+      tagUuids: tags,
+      text: node.description,
+      title: node.name,
+      uuid: this.getEventUUID(node.id),
+    };
 
-  const featureQuestions = nodes
-    .filter((node): node is Feature => node.type === "feature")
-    .reduce<Record<string, ReturnType<typeof eventsFromCategoryNode>>>(
-      (acc, node) => {
-        const parentUuid = attributeQuestions[node.parentId]?.elaborateUuid;
-        if (parentUuid) {
-          acc[node.id] = eventsFromCategoryNode(
-            node,
-            parentUuid,
-            Object.values(sliceTags)
-              .filter((t) => t.elements.has(node.id))
-              .map((t) => t.event.entityUuid)
-          );
-        }
-        return acc;
-      },
-      {}
-    );
+    const standardAnswers = [
+      ["Elaborate now", "elaborate-now"],
+      ["Elaborate later", "elaborate-later"],
+      ["Not relevant", "not-relevant"],
+    ].map<Event>(([label, id]) => ({
+      eventType: "AddAnswerEvent",
+      uuid: this.getEventUUID(node.id + ":" + id),
+      parentUuid: question.entityUuid,
+      entityUuid: this.getStableUUID(node.id + ":" + id),
+      createdAt: createdAt,
+      label: label,
+      advice: null,
+      metricMeasures: [],
+      annotations: [],
+    }));
+    const elaborateUuid = standardAnswers[0].entityUuid;
 
-  return {
-    createdAt: createdAt,
-    forkOfPackageId: null as unknown as undefined,
-    id: `${organizationId}:${kmId}:${version}`,
-    kmId: kmId,
-    license: "Apache 2.0",
-    mergeCheckpointPackageId: null as unknown as undefined,
-    metamodelVersion: 17,
-    name: name,
-    nonEditable: false,
-    organizationId: organizationId,
-    phase: "ReleasedPackagePhase",
-    previousPackageId: null as unknown as undefined,
-    description: `This is an export from the repository ${name}`,
-    readme: `This is an export from the repository ${name}`,
-    version: version,
-    events: [
-      {
-        annotations: [],
-        createdAt: createdAt,
-        entityUuid: kmUuid,
-        eventType: "AddKnowledgeModelEvent",
-        parentUuid: parentUuid,
-        uuid: uuidv4(),
-      },
-      ...Object.values(sliceTags).map((t) => t.event),
-      ...Object.values(mainChapterEvents),
-      ...Object.values(categoryQuestions).flatMap((d) => d.events),
-      ...Object.values(subcategoryQuestions).flatMap((d) => d.events),
-      ...Object.values(attributeQuestions).flatMap((d) => d.events),
-      ...Object.values(featureQuestions).flatMap((d) => d.events),
-    ],
-  };
-}
+    const overviewAnswer: Event = {
+      eventType: "AddQuestionEvent",
+      uuid: this.getEventUUID(node.id + ":elaborate-now:answer"),
+      parentUuid: elaborateUuid,
+      entityUuid: this.getStableUUID(node.id + ":elaborate-now:answer"),
+      createdAt: createdAt,
+      questionType: "ValueQuestion",
+      title: `Overview of ${node.name}`,
+      text: "",
+      requiredPhaseUuid: null,
+      tagUuids: tags,
+      valueType: "TextQuestionValueType",
+      validations: [],
+      annotations: [],
+    };
+    return {
+      elaborateUuid: elaborateUuid,
+      questionUuid: question.entityUuid,
+      events: [question, ...standardAnswers, overviewAnswer],
+    };
+  }
 
-function tagFromSlice(slice: ThematicSlice, parentUuid: UUID): Event {
-  const createdAt = new Date().toISOString();
-  return {
-    eventType: "AddTagEvent",
-    uuid: uuidv4(),
-    parentUuid: parentUuid,
-    entityUuid: uuidv4(),
-    createdAt: createdAt,
-    name: slice.label,
-    description: null,
-    color: "",
-    annotations: [],
-  };
-}
+  protected eventFromRootNode(node: GORCNode, parentUuid: string): Event {
+    const createdAt = new Date().toISOString();
+    return {
+      annotations: [],
+      createdAt: createdAt,
+      entityUuid: this.getEventUUID(node.id),
+      eventType: "AddChapterEvent",
+      parentUuid: parentUuid,
+      text: node.description,
+      title: node.name,
+      uuid: this.getStableUUID(node.id),
+    };
+  }
 
-function eventsFromCategoryNode(
-  node: Category | Subcategory | Attribute | Feature,
-  parentUuid: string,
-  tags: UUID[]
-): {
-  elaborateUuid: UUID;
-  questionUuid: UUID;
-  events: Event[];
-} {
-  const createdAt = new Date().toISOString();
+  protected getStableUUID(base: string): string {
+    return this.registerUUID(uuidv5(base, this._namespace));
+  }
 
-  const question: Event = {
-    annotations: [],
-    createdAt: createdAt,
-    entityUuid: uuidv4(),
-    eventType: "AddQuestionEvent",
-    parentUuid: parentUuid,
-    questionType: "OptionsQuestion",
-    requiredPhaseUuid: null,
-    tagUuids: tags,
-    text: node.description,
-    title: node.name,
-    uuid: uuidv4(),
-  };
+  protected getEventUUID(id: string): string {
+    const tick = this.getTick(id);
+    return this.registerUUID(
+      uuidv5(`event-${id}-${tick}`, this._namespace)
+    )
+  }
 
-  const standardAnswers = [
-    "Elaborate now",
-    "Elaborate later",
-    "Not relevant",
-  ].map<Event>((label) => ({
-    eventType: "AddAnswerEvent",
-    uuid: uuidv4(),
-    parentUuid: question.entityUuid,
-    entityUuid: uuidv4(),
-    createdAt: createdAt,
-    label: label,
-    advice: null,
-    metricMeasures: [],
-    annotations: [],
-  }));
-  const elaborateUuid = standardAnswers[0].entityUuid;
+  protected registerUUID(uuid: string) {
+    if (this._uuidSet.has(uuid)) {
+      throw new Error(`Duplicate UUID detected: '${uuid}'`)
+    } else {
+      this._uuidSet.add(uuid)
+    }
+    return uuid
+  }
 
-  const overviewAnswer: Event = {
-    eventType: "AddQuestionEvent",
-    uuid: uuidv4(),
-    parentUuid: elaborateUuid,
-    entityUuid: uuidv4(),
-    createdAt: createdAt,
-    questionType: "ValueQuestion",
-    title: `Overview of ${node.name}`,
-    text: "",
-    requiredPhaseUuid: null,
-    tagUuids: tags,
-    valueType: "TextQuestionValueType",
-    validations: [],
-    annotations: [],
-  };
-  return {
-    elaborateUuid: elaborateUuid,
-    questionUuid: question.entityUuid,
-    events: [question, ...standardAnswers, overviewAnswer],
-  };
-}
-
-function eventFromRootNode(node: GORCNode, parentUuid: string): Event {
-  const createdAt = new Date().toISOString();
-  return {
-    annotations: [],
-    createdAt: createdAt,
-    entityUuid: uuidv4(),
-    eventType: "AddChapterEvent",
-    parentUuid: parentUuid,
-    text: node.description,
-    title: node.name,
-    uuid: uuidv4(),
-  };
+  protected getTick(id: string): number {
+    return this._idTickers[id] = this._idTickers[id] || 0 + 1;
+  }
 }

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -5,7 +5,7 @@ import {
   Feature,
   Attribute,
 } from "../GORCNodes";
-import { ModelDefinition, ModelLayerDefinition, ThematicSlice, ModelNode, getModelNodes, Nothing, ModelProfile } from "../LayeredModel";
+import { BaseModel, ModelDefinition, ModelLayerDefinition, ThematicSlice, ModelNode, getModelNodes, Nothing, ModelProfile } from "../LayeredModel";
 import { Package, PackageBundle, Event, UUID, AddChapterEvent, AddListQuestionEvent, AddItemSelectQuestionEvent, AddAnswerEvent } from "./types";
 import { v5 as uuidv5 } from "uuid";
 
@@ -16,7 +16,32 @@ export class KMPackager {
   private _uuidSet = new Set<string>();
   private _useIdChecks = true;
 
-  createPackageBundleObject(
+  createBundle(
+    model: BaseModel,
+    slices: ThematicSlice[],
+    profiles: ModelProfile[],
+    organizationId: string,
+  ): PackageBundle {
+    const kmId: string = model.id;
+    const version: string = model.version;
+    return this.createPackageBundleObject(
+      model.label,
+      this.createKMPackages(
+        model,
+        slices,
+        profiles,
+        model.label,
+        kmId,
+        version,
+        organizationId
+      ),
+      kmId,
+      version,
+      organizationId
+    );
+  }
+
+  protected createPackageBundleObject(
     name: string,
     packages: Package[],
     kmId: string,
@@ -34,7 +59,7 @@ export class KMPackager {
     };
   }
 
-  createKMPackages(
+  protected createKMPackages(
     modelDefinition: ModelDefinition,
     slices: ThematicSlice[],
     profiles: ModelProfile[],
@@ -264,7 +289,7 @@ export class KMPackager {
 
     const updates = baseEvents.filter((event): event is AddChapterEvent | AddListQuestionEvent | AddItemSelectQuestionEvent | AddAnswerEvent => {
       return event.eventType === "AddChapterEvent" || event.eventType === "AddAnswerEvent" || event.eventType === "AddQuestionEvent";
-    });
+    }).map(event => this.editEventFromAddEvent(event));
 
     return [
       ...removals,

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -63,21 +63,9 @@ export class KMPackager {
       parentUuid,
     )
 
-    const profileEvents = profiles.map<{id: string, profileKmId: string, profile: ModelProfile, events: Event[]}>((profile, index, items) => {
-      const baseId = [kmId, ...items.slice(0, index + 1).map(i => i.id)].join("-wp-")
-      return {
-        id: `${organizationId}:${baseId}:${profile.version}`,
-        profileKmId: baseId,
-        profile: profile,
-        events: this.eventsFromProfile(
-          profile,
-          sliceTags,
-          kmUuid
-        )
-      }
-    }, {});
-
     const mainPackageId = `${organizationId}:${kmId}:${version}`;
+    const profileKmId = [kmId, ...profiles.map(i => i.id)].join("-wp-")
+    const profileName = profiles.map(profile => profile.label).join(" and ")
     return [
       {
         createdAt: createdAt,
@@ -108,28 +96,28 @@ export class KMPackager {
           ...events,
         ],
       },
-      ...profileEvents.map<Package>(({id, profileKmId, profile, events}, index, items) => {
-        const forkOfPackageId = items[index - 1] ? items[index - 1].id : mainPackageId;
-        const profiles = items.slice(0, index + 1).map(i => i.profile.label).join(" and ")
-        return {
-          createdAt: createdAt,
-          forkOfPackageId: forkOfPackageId,
-          id: id,
-          kmId: profileKmId,
-          license: "Apache 2.0",
-          mergeCheckpointPackageId: forkOfPackageId,
-          metamodelVersion: 17,
-          name: `${name} with profile ${profiles}`,
-          nonEditable: false,
-          organizationId: organizationId,
-          phase: "ReleasedPackagePhase",
-          previousPackageId: forkOfPackageId,
-          description: `Profile ${profiles} from repository ${name}`,
-          readme: `Profile ${profiles} from repository ${name}`,
-          version: profile.version,
-          events: events,
-        }
-      })
+      {
+        createdAt: createdAt,
+        forkOfPackageId: mainPackageId,
+        id: `${organizationId}:${profileKmId}:${version}`,
+        kmId: profileKmId,
+        license: "Apache 2.0",
+        mergeCheckpointPackageId: mainPackageId,
+        metamodelVersion: 17,
+        name: `${name} with profile ${profileName}`,
+        nonEditable: false,
+        organizationId: organizationId,
+        phase: "ReleasedPackagePhase",
+        previousPackageId: mainPackageId,
+        description: `${name} with applied profiles ${profileName}`,
+        readme: `${name} with applied profiles ${profileName}`,
+        version: version,
+        events: profiles.flatMap(profile => this.eventsFromProfile(
+          profile,
+          sliceTags,
+          kmUuid
+        )),
+      }
     ];
   }
 

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -5,8 +5,8 @@ import {
   Feature,
   Attribute,
 } from "../GORCNodes";
-import { ModelDefinition, ThematicSlice, getModelNodes } from "../LayeredModel";
-import { Package, PackageBundle, Event, UUID } from "./types";
+import { ModelDefinition, ModelLayerDefinition, ThematicSlice, ModelNode, getModelNodes, Nothing } from "../LayeredModel";
+import { Package, PackageBundle, Event, UUID, AddChapterEvent, AddListQuestionEvent, AddItemSelectQuestionEvent, AddAnswerEvent } from "./types";
 import { v5 as uuidv5 } from "uuid";
 
 
@@ -34,8 +34,9 @@ export class KMPackager {
   }
 
   createKMPackage(
-    modelDefintion: ModelDefinition,
+    modelDefinition: ModelDefinition,
     slices: ThematicSlice[],
+    profiles: ModelLayerDefinition[],
     name: string,
     kmId: string,
     version: string,
@@ -44,14 +45,6 @@ export class KMPackager {
     const createdAt = this.getDateStr();
     const parentUuid = "00000000-0000-0000-0000-000000000000";
     const kmUuid = this.getStableUUID(kmId);
-    const nodes = getModelNodes(modelDefintion);
-    const mainChapterEvents = nodes
-      .filter((node): node is GORCNode => node.type !== "question")
-      .filter((node) => !("parentId" in node))
-      .reduce<Record<string, Event>>((acc, n) => {
-        acc[n.id] = this.eventFromRootNode(n, parentUuid);
-        return acc;
-      }, {});
 
     const sliceTags = slices.reduce<
       Record<string, { event: Event; elements: Set<string> }>
@@ -62,6 +55,64 @@ export class KMPackager {
       };
       return acc;
     }, {});
+
+    const nodes = getModelNodes(modelDefinition);
+    const events = this.eventsFromNodes(
+      nodes,
+      sliceTags,
+      parentUuid,
+    )
+
+    const profileEvents = profiles.flatMap(profile => this.eventsFromProfile(
+      profile,
+      sliceTags,
+      parentUuid
+    ))
+
+    return {
+      createdAt: createdAt,
+      forkOfPackageId: null as unknown as undefined,
+      id: `${organizationId}:${kmId}:${version}`,
+      kmId: kmId,
+      license: "Apache 2.0",
+      mergeCheckpointPackageId: null as unknown as undefined,
+      metamodelVersion: 17,
+      name: name,
+      nonEditable: false,
+      organizationId: organizationId,
+      phase: "ReleasedPackagePhase",
+      previousPackageId: null as unknown as undefined,
+      description: `This is an export from the repository ${name}`,
+      readme: `This is an export from the repository ${name}`,
+      version: version,
+      events: [
+        {
+          annotations: [],
+          createdAt: createdAt,
+          entityUuid: kmUuid,
+          eventType: "AddKnowledgeModelEvent",
+          parentUuid: parentUuid,
+          uuid: this.getEventUUID(kmId),
+        },
+        ...Object.values(sliceTags).map((t) => t.event),
+        ...events,
+        ...profileEvents,
+      ],
+    };
+  }
+
+  protected eventsFromNodes(
+    nodes: ModelNode[],
+    sliceTags: Record<string, { event: Event; elements: Set<string> }>,
+    parentUuid: string
+  ): Event[] {
+    const mainChapterEvents = nodes
+      .filter((node): node is GORCNode => node.type !== "question")
+      .filter((node) => !("parentId" in node))
+      .reduce<Record<string, Event>>((acc, n) => {
+        acc[n.id] = this.eventFromRootNode(n, parentUuid);
+        return acc;
+      }, {});
 
     const categoryQuestions = nodes
       .filter((node): node is Category => node.type === "category")
@@ -136,39 +187,13 @@ export class KMPackager {
         {}
       );
 
-    return {
-      createdAt: createdAt,
-      forkOfPackageId: null as unknown as undefined,
-      id: `${organizationId}:${kmId}:${version}`,
-      kmId: kmId,
-      license: "Apache 2.0",
-      mergeCheckpointPackageId: null as unknown as undefined,
-      metamodelVersion: 17,
-      name: name,
-      nonEditable: false,
-      organizationId: organizationId,
-      phase: "ReleasedPackagePhase",
-      previousPackageId: null as unknown as undefined,
-      description: `This is an export from the repository ${name}`,
-      readme: `This is an export from the repository ${name}`,
-      version: version,
-      events: [
-        {
-          annotations: [],
-          createdAt: createdAt,
-          entityUuid: kmUuid,
-          eventType: "AddKnowledgeModelEvent",
-          parentUuid: parentUuid,
-          uuid: this.getEventUUID(kmId),
-        },
-        ...Object.values(sliceTags).map((t) => t.event),
+      return [
         ...Object.values(mainChapterEvents),
         ...Object.values(categoryQuestions).flatMap((d) => d.events),
         ...Object.values(subcategoryQuestions).flatMap((d) => d.events),
         ...Object.values(attributeQuestions).flatMap((d) => d.events),
         ...Object.values(featureQuestions).flatMap((d) => d.events),
-      ],
-    };
+      ]
   }
 
   protected tagFromSlice(slice: ThematicSlice, parentUuid: UUID): Event {
@@ -184,6 +209,142 @@ export class KMPackager {
       color: "",
       annotations: [],
     };
+  }
+
+  protected eventsFromProfile(
+    profile: ModelLayerDefinition,
+    sliceTags: Record<string, { event: Event; elements: Set<string> }>,
+    parentUuid: string
+  ): Event[] {
+    const removals = profile.nodes
+      .filter((node): node is Nothing => node.type === "nothing")
+      .map(node => this.eventFromNothingNode(node, parentUuid));
+
+    const updatedNodes = profile.nodes
+      .filter((node): node is GORCNode => node.type !== "question" && node.type !== "nothing")
+    
+    const baseEvents = this.eventsFromNodes(
+      updatedNodes,
+      sliceTags,
+      parentUuid,
+    )
+
+    const updates = baseEvents.filter((event): event is AddChapterEvent | AddListQuestionEvent | AddItemSelectQuestionEvent | AddAnswerEvent => {
+      return event.eventType === "AddChapterEvent" || event.eventType === "AddAnswerEvent" || event.eventType === "AddQuestionEvent";
+    });
+
+    console.log(removals, updates)
+
+    return [
+      ...removals,
+      ...updates
+    ]
+  }
+
+  protected eventFromNothingNode(node: Nothing, parentUuid: string): Event {
+    return {
+      eventType: "DeleteChapterEvent",
+      uuid: this.getEventUUID(node.id),
+      entityUuid: this.getStableUUID(node.id),
+      parentUuid: parentUuid,
+      createdAt: this.getDateStr()
+    };
+  }
+
+  protected editEventFromAddEvent(
+    event: AddChapterEvent | AddListQuestionEvent | AddItemSelectQuestionEvent | AddAnswerEvent
+  ): Event {
+    switch(event.eventType) {
+      case "AddAnswerEvent": {
+        return {
+          eventType: "EditAnswerEvent",
+          uuid: event.uuid,
+          parentUuid: event.parentUuid,
+          entityUuid: event.entityUuid,
+          createdAt: event.createdAt,
+          label: {
+            changed: true,
+            value: event.label, 
+          },
+          advice: {
+            changed: true,
+            value: event.advice,
+          },
+          followUpUuids: {
+            changed: false,
+          },
+          metricMeasures: {
+            changed: false,
+          },
+          annotations: {
+            changed: true,
+            value: event.annotations,
+          }
+        }
+      }
+      case "AddChapterEvent": {
+        return {
+          annotations: {
+            value: event.annotations,
+            changed: true,
+          },
+          createdAt: event.createdAt,
+          entityUuid: event.entityUuid,
+          eventType: "EditChapterEvent",
+          parentUuid: event.parentUuid,
+          text: {
+            changed: true,
+            value: event.text,
+          },
+          title: {
+            changed: true,
+            value: event.title
+          },
+          questionUuids: {
+            changed: false,
+          },
+          uuid: event.uuid,
+        }
+      }
+      case "AddQuestionEvent": {
+        return {
+          eventType: "EditQuestionEvent",
+          uuid: event.uuid,
+          parentUuid: event.parentUuid,
+          entityUuid: event.entityUuid,
+          createdAt: event.createdAt,
+          questionType: "OptionsQuestion",
+          title: {
+            changed: true,
+            value: event.title,
+          },
+          text: {
+            changed: true,
+            value: event.text,
+          },
+          requiredPhaseUuid: {
+            changed: true,
+            value: event.requiredPhaseUuid,
+          },
+          tagUuids: {
+            changed: false,
+          },
+          expertUuids: {
+            changed: false,
+          },
+          referenceUuids: {
+            changed: false,
+          },
+          answerUuids: {
+            changed: false,
+          },
+          annotations: {
+            changed: true,
+            value: event.annotations,
+          },
+        }
+      }
+    }
   }
 
   protected eventsFromCategoryNode(
@@ -255,12 +416,12 @@ export class KMPackager {
     return {
       annotations: [],
       createdAt: createdAt,
-      entityUuid: this.getEventUUID(node.id),
+      entityUuid: this.getStableUUID(node.id),
       eventType: "AddChapterEvent",
       parentUuid: parentUuid,
       text: node.description,
       title: node.name,
-      uuid: this.getStableUUID(node.id),
+      uuid: this.getEventUUID(node.id),
     };
   }
 
@@ -277,7 +438,7 @@ export class KMPackager {
 
   protected registerUUID(uuid: string) {
     if (this._uuidSet.has(uuid)) {
-      throw new Error(`Duplicate UUID detected: '${uuid}'`)
+      //throw new Error(`Duplicate UUID detected: '${uuid}'`)
     } else {
       this._uuidSet.add(uuid)
     }

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -15,6 +15,11 @@ export class KMPackager {
   private _namespace = uuidv5("rda-gorc-im", "00000000-0000-0000-0000-000000000000");
   private _uuidSet = new Set<string>();
   private _useIdChecks = true;
+  private _baseDate;
+
+  constructor(baseDate = new Date()) {
+    this._baseDate = baseDate;
+  }
 
   createBundle(
     model: BaseModel,
@@ -506,6 +511,6 @@ export class KMPackager {
   }
 
   protected getDateStr() {
-    return new Date().toISOString()
+    return this._baseDate.toISOString()
   }
 }

--- a/src/modules/DSWExport/export.ts
+++ b/src/modules/DSWExport/export.ts
@@ -13,7 +13,8 @@ import { v5 as uuidv5 } from "uuid";
 export class KMPackager {
   private _idTickers: Record<string, number> = {};
   private _namespace = uuidv5("rda-gorc-im", "00000000-0000-0000-0000-000000000000");
-  private _uuidSet = new Set<string>()
+  private _uuidSet = new Set<string>();
+  private _useIdChecks = true;
 
   createPackageBundleObject(
     name: string,
@@ -96,7 +97,7 @@ export class KMPackager {
           ...events,
         ],
       },
-      {
+      this.runWithoutIdChecks(() => ({
         createdAt: createdAt,
         forkOfPackageId: mainPackageId,
         id: `${organizationId}:${profileKmId}:${version}`,
@@ -117,7 +118,7 @@ export class KMPackager {
           sliceTags,
           kmUuid
         )),
-      }
+      }))
     ];
   }
 
@@ -216,6 +217,18 @@ export class KMPackager {
       ]
   }
 
+  protected runWithoutIdChecks<T>(func: () => T): T {
+    this._useIdChecks = false;
+    try {
+      const result = func();
+      this._useIdChecks = true;
+      return result;
+    } catch (e) {
+      this._useIdChecks = true;
+      throw e;
+    }
+  }
+
   protected tagFromSlice(slice: ThematicSlice, parentUuid: UUID): Event {
     const createdAt = this.getDateStr();
     return {
@@ -252,8 +265,6 @@ export class KMPackager {
     const updates = baseEvents.filter((event): event is AddChapterEvent | AddListQuestionEvent | AddItemSelectQuestionEvent | AddAnswerEvent => {
       return event.eventType === "AddChapterEvent" || event.eventType === "AddAnswerEvent" || event.eventType === "AddQuestionEvent";
     });
-
-    console.log(removals, updates)
 
     return [
       ...removals,
@@ -458,7 +469,7 @@ export class KMPackager {
 
   protected registerUUID(uuid: string) {
     if (this._uuidSet.has(uuid)) {
-      //throw new Error(`Duplicate UUID detected: '${uuid}'`)
+      if (this._useIdChecks) throw new Error(`Duplicate UUID detected: '${uuid}'`)
     } else {
       this._uuidSet.add(uuid)
     }

--- a/src/modules/LayeredModel.ts
+++ b/src/modules/LayeredModel.ts
@@ -26,6 +26,7 @@ export type Package = {
   id: PackageId;
   label: string;
   version: SemanticVersionString;
+  updatedAt?: string;
 };
 
 export type ModelRelation = {

--- a/src/modules/Validation.ts
+++ b/src/modules/Validation.ts
@@ -220,6 +220,7 @@ export function parsePackage<T>(
         id: parseType("string"),
         label: parseType("string"),
         version: parseType("string"),
+        updatedAt: parseOptional(parseType("string")),
       };
       const packageInfo: Package = parseObject(data, parsers, "parsePackage");
       const packageData: T = parser(data);


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related Issues
This PR closes #91 and #90

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Changes
<!-- List key changes, ideally in bullet form. -->
- Make sure that UUIDs generated by the export are stable as long as the ids of the content are stable
- Allow datestamps to be stable when the model includes "updatedAt"
- Add support for exporting profiles
- Add profile to OSS model in example repo

## Testing
Your `public/config.json` should look as follows:
```json
{
  "title": "This is my GORC IM",
  "useHashRouter": true,
  "repositories": [
    {
      "url": "repos/example-repo/root.json",
      "id": "example-repo",
      "name": "Example Repo"
    },
    {
      "url": "https://raw.githubusercontent.com/pdmnyberg/gorc-example-repo/refs/heads/main/gorc-and-oss/root.json",
      "id": "gorc-and-oss",
      "name": "GORC and OSS"
    }
  ]
}
```

- build the updated example repo by: `docker compose exec vite npm run build-examples`
- start the app
- use the OSS model from the example repo
- apply the dual license profile
- Export to DSW
- Import the file into DSW
- Expect DSW to get two new KMs `OSS Base Model` and `OSS Base Model with profile OSS Dual-License Model]`
- Make sure the KMs looks as expected
- Export to DSW again with the same settings
- Run a diff on the files and expect them to be exactly the same

## Further comments

<!-- Specify questions or related information -->

## Checklist
- [x] Code builds and runs
- [x] Tests have been added/updated
- [x] Documentation updated (if needed)

<!-- Optional: include screenshots, links, or any other context. -->
