### PR TITLE
Add related node navigation

### DIFF
--- a/src/components/GORCNodeView/GORCNodeView.css
+++ b/src/components/GORCNodeView/GORCNodeView.css
@@ -162,4 +162,7 @@
   padding: calc(var(--gorc-node-size) / 2);
   background-color: var(--gorc-node-text-background-color);
   border-radius: 0.5rem;
+  transition: 
+    background-color var(--gorc-node-animation-time),
+    color var(--gorc-node-animation-time);
 }

--- a/src/components/GORCNodeView/GORCNodeView.css
+++ b/src/components/GORCNodeView/GORCNodeView.css
@@ -20,9 +20,9 @@
   height: 30px;
 }
 
-.gorc-node-root.selected {
-  outline: 3px solid var(--theme-navy);
-  border-radius: 4px;
+.gorc-node-root.selected .gorc-node-text {
+  background-color: var(--color-core);
+  color: white;
 }
 
 .gorc-node-body {
@@ -157,7 +157,9 @@
 }
 
 .gorc-node-text {
+  margin-top: 0.25rem;
   text-align: center;
   padding: calc(var(--gorc-node-size) / 2);
   background-color: var(--gorc-node-text-background-color);
+  border-radius: 0.5rem;
 }

--- a/src/components/GORCNodeView/GORCNodeView.tsx
+++ b/src/components/GORCNodeView/GORCNodeView.tsx
@@ -1,15 +1,18 @@
 import { Handle, Position } from "@xyflow/react";
 import { GORCNode } from "../../modules/GORCNodes";
 import "./GORCNodeView.css";
+import { useNodeSelection } from "../../contexts/SelectionContexts";
 
 type Props = {
-  data: GORCNode & { isSelected?: boolean };
+  data: GORCNode;
 };
 
 export function GORCNodeView({ data }: Props) {
+  const nodeSelection = useNodeSelection();
+  const selectedNode = nodeSelection[0]
   return (
     <div
-      className={`gorc-node-root${data.isSelected ? " selected" : ""}`}
+      className={`gorc-node-root${selectedNode && data.id === selectedNode.id ? " selected" : ""}`}
       data-type={data.type}
       data-consideration-level={data.considerationLevel}
     >

--- a/src/components/SidePanel/SidePanel.css
+++ b/src/components/SidePanel/SidePanel.css
@@ -71,3 +71,13 @@
 .badge.optional {
   background-color: var(--color-optional-light);
 }
+
+.node-link {
+  cursor: pointer;
+  background-color: rgba(0, 0, 0, 0.0);
+  transition: background-color 0.1s;
+}
+
+.node-link:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}

--- a/src/components/SidePanel/SidePanel.css
+++ b/src/components/SidePanel/SidePanel.css
@@ -39,7 +39,8 @@
 }
 
 .badge-group {
-  white-space: nowrap;
+  display: inline-block;
+  margin: 0.25rem 0;
 }
 
 .badge-type {
@@ -70,6 +71,15 @@
 
 .badge.optional {
   background-color: var(--color-optional-light);
+}
+
+.badge.essential-element, 
+.badge.category, 
+.badge.subcategory, 
+.badge.attribute, 
+.badge.feature
+{
+  background-color: var(--color-core-light);
 }
 
 .node-link {

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -1,12 +1,11 @@
-import type { Node } from "@xyflow/react";
-import { GORCNode, KPI } from "../../modules/GORCNodes";
+import { KPI } from "../../modules/GORCNodes";
 import "./SidePanel.css";
 import { PanelWrapper } from "../PanelWrapper/PanelWrapper";
 import React from "react";
 import { useModel } from "../../contexts/ModelContext";
+import { NodeSelectionManager } from "../../contexts/SelectionContexts";
 
 type Props = {
-  node: Node<GORCNode> | null;
   onClose: () => void;
 };
 
@@ -18,14 +17,16 @@ function BadgeGroup({type, value}: {type: string, value: string}) {
   )
 }
 
-export const SidePanel = ({ node, onClose }: Props) => {
+export const SidePanel = ({ onClose }: Props) => {
+  const nodeSelection = React.useContext(NodeSelectionManager);
+  const node = nodeSelection[0]
+  const setNode = nodeSelection[2]
+
   const [isOpen, setIsOpen] = React.useState(false);
-  const [displayedNode, setDisplayedNode] = React.useState<typeof node>(null);
   const modelDefintion = useModel();
 
   React.useEffect(() => {
     if (node) {
-      setDisplayedNode(node);
       setIsOpen(true);
     }
   }, [node]);
@@ -34,21 +35,20 @@ export const SidePanel = ({ node, onClose }: Props) => {
     setIsOpen(false);
     onClose();
     setTimeout(() => {
-      setDisplayedNode(null);
+      setNode(null);
     }, 100);
   };
 
-  const data = displayedNode?.data;
   const kpiNodes = React.useMemo(() => (
-    data ? modelDefintion.nodes.filter((n): n is KPI => ["kpi", "metric"].includes(n.type)).filter(kpi => kpi.measurementOf.includes(data.id) || kpi.indicatorOf.includes(data.id)) : []
-  ), [modelDefintion.nodes, data]);
+    node ? modelDefintion.nodes.filter((n): n is KPI => ["kpi", "metric"].includes(n.type)).filter(kpi => kpi.measurementOf.includes(node.id) || kpi.indicatorOf.includes(node.id)) : []
+  ), [modelDefintion.nodes, node]);
 
   const parent = React.useMemo(() => (
-    data && "childOf" in data ? modelDefintion.nodes.filter((n) => n.id === data.childOf)[0] : null
-  ), [modelDefintion.nodes, data])
+    node && "childOf" in node ? modelDefintion.nodes.filter((n) => n.id === node.childOf)[0] : null
+  ), [modelDefintion.nodes, node])
   const childNodes = React.useMemo(() => (
-    data ? modelDefintion.nodes.filter((n) => "childOf" in n && n.childOf === data.id) : []
-  ), [modelDefintion.nodes, data])
+    node ? modelDefintion.nodes.filter((n) => "childOf" in n && n.childOf === node.id) : []
+  ), [modelDefintion.nodes, node])
 
   return (
     <PanelWrapper position="left" visible={isOpen}>
@@ -59,49 +59,45 @@ export const SidePanel = ({ node, onClose }: Props) => {
       >
         ×
       </button>
-      {displayedNode ? (
-        data ? (
-          <>
-            <h2>{data.shortName}</h2>
-            <h3>{data.name}</h3>
-            <p className="data-type">{data.type}</p>
-            {data.description && <p>{data.description}</p>}
-            <BadgeGroup type="Consideration Level" value={data.considerationLevel} />
+      {node ? (
+        <>
+          <h2>{node.shortName}</h2>
+          <h3>{node.name}</h3>
+          <p className="data-type">{node.type}</p>
+          {node.description && <p>{node.description}</p>}
+          <BadgeGroup type="Consideration Level" value={node.considerationLevel} />
 
-            <hr />
-            {parent ? <>
-              <h3>Parent</h3>
-              <ul>
-                <li>{parent.name} <BadgeGroup type="Consideration Level" value={parent.considerationLevel} /></li>
-              </ul>
-            </> : <></>}
-            {childNodes.length ? <>
-              <h3>Children</h3>
-              <ul>
-                {childNodes.map(n => (
+          <hr />
+          {parent ? <>
+            <h3>Parent</h3>
+            <ul>
+              <li><a className="node-link" onClick={() => setNode(parent)}>{parent.name}</a> <BadgeGroup type="Consideration Level" value={parent.considerationLevel} /></li>
+            </ul>
+          </> : <></>}
+          {childNodes.length ? <>
+            <h3>Children</h3>
+            <ul>
+              {childNodes.map(n => (
+                  <li key={n.id}><a className="node-link" onClick={() => setNode(n)}>{n.name}</a> <BadgeGroup type="Consideration Level" value={n.considerationLevel} /></li>
+                ))}
+            </ul>
+          </> : <></>}
+
+          <hr />
+          {[{type: "kpi", label: "KPIs"}, {type: "metric", label: "Metrics"}].map(({type, label}) => {
+            const filteredNodes = kpiNodes.filter(n => n.type === type)
+            return filteredNodes.length > 0 ? (
+              <React.Fragment key={type}>
+                <h3>{label}</h3>
+                <ul>
+                  {filteredNodes.map(n => (
                     <li key={n.id}>{n.name} <BadgeGroup type="Consideration Level" value={n.considerationLevel} /></li>
                   ))}
-              </ul>
-            </> : <></>}
-
-            <hr />
-            {[{type: "kpi", label: "KPIs"}, {type: "metric", label: "Metrics"}].map(({type, label}) => {
-              const filteredNodes = kpiNodes.filter(n => n.type === type)
-              return filteredNodes.length > 0 ? (
-                <React.Fragment key={type}>
-                  <h3>{label}</h3>
-                  <ul>
-                    {filteredNodes.map(n => (
-                      <li key={n.id}>{n.name} <BadgeGroup type="Consideration Level" value={n.considerationLevel} /></li>
-                    ))}
-                  </ul>
-                </React.Fragment>
-              ) : <React.Fragment key={type}></React.Fragment>
-            })}
-          </>
-        ) : (
-          "No data available"
-        )
+                </ul>
+              </React.Fragment>
+            ) : <React.Fragment key={type}></React.Fragment>
+          })}
+        </>
       ) : (
         (null as React.ReactNode)
       )}

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -9,10 +9,11 @@ type Props = {
   onClose: () => void;
 };
 
-function BadgeGroup({type, value}: {type: string, value: string}) {
+function BadgeGroup({type, value, badgeType}: {type: string, value: string, badgeType?: string}) {
+  badgeType = badgeType || value
   return (
     <span className="badge-group">
-      <span className="badge-type">{type}</span><span className={`badge ${value}`}>{value}</span>
+      <span className="badge-type">{type}</span><span className={`badge ${badgeType}`}>{value}</span>
     </span>
   )
 }
@@ -71,14 +72,22 @@ export const SidePanel = ({ onClose }: Props) => {
           {parent ? <>
             <h3>Parent</h3>
             <ul>
-              <li><a className="node-link" onClick={() => setNode(parent)}>{parent.name}</a> <BadgeGroup type="Consideration Level" value={parent.considerationLevel} /></li>
+              <li>
+                <a className="node-link" onClick={() => setNode(parent)}>{parent.name}</a>
+                <BadgeGroup type="Type" value={parent.type} badgeType={parent.considerationLevel} />
+                <BadgeGroup type="Consideration Level" value={parent.considerationLevel} />
+              </li>
             </ul>
           </> : <></>}
           {childNodes.length ? <>
             <h3>Children</h3>
             <ul>
               {childNodes.map(n => (
-                  <li key={n.id}><a className="node-link" onClick={() => setNode(n)}>{n.name}</a> <BadgeGroup type="Consideration Level" value={n.considerationLevel} /></li>
+                  <li key={n.id}>
+                    <a className="node-link" onClick={() => setNode(n)}>{n.name}</a>
+                    <BadgeGroup type="Type" value={n.type} badgeType={n.considerationLevel} />
+                    <BadgeGroup type="Consideration Level" value={n.considerationLevel} />
+                  </li>
                 ))}
             </ul>
           </> : <></>}

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -41,7 +41,14 @@ export const SidePanel = ({ node, onClose }: Props) => {
   const data = displayedNode?.data;
   const kpiNodes = React.useMemo(() => (
     data ? modelDefintion.nodes.filter((n): n is KPI => ["kpi", "metric"].includes(n.type)).filter(kpi => kpi.measurementOf.includes(data.id) || kpi.indicatorOf.includes(data.id)) : []
-  ), [modelDefintion, data])
+  ), [modelDefintion.nodes, data]);
+
+  const parent = React.useMemo(() => (
+    data && "childOf" in data ? modelDefintion.nodes.filter((n) => n.id === data.childOf)[0] : null
+  ), [modelDefintion.nodes, data])
+  const childNodes = React.useMemo(() => (
+    data ? modelDefintion.nodes.filter((n) => "childOf" in n && n.childOf === data.id) : []
+  ), [modelDefintion.nodes, data])
 
   return (
     <PanelWrapper position="left" visible={isOpen}>
@@ -60,6 +67,24 @@ export const SidePanel = ({ node, onClose }: Props) => {
             <p className="data-type">{data.type}</p>
             {data.description && <p>{data.description}</p>}
             <BadgeGroup type="Consideration Level" value={data.considerationLevel} />
+
+            <hr />
+            {parent ? <>
+              <h3>Parent</h3>
+              <ul>
+                <li>{parent.name} <BadgeGroup type="Consideration Level" value={parent.considerationLevel} /></li>
+              </ul>
+            </> : <></>}
+            {childNodes.length ? <>
+              <h3>Children</h3>
+              <ul>
+                {childNodes.map(n => (
+                    <li key={n.id}>{n.name} <BadgeGroup type="Consideration Level" value={n.considerationLevel} /></li>
+                  ))}
+              </ul>
+            </> : <></>}
+
+            <hr />
             {[{type: "kpi", label: "KPIs"}, {type: "metric", label: "Metrics"}].map(({type, label}) => {
               const filteredNodes = kpiNodes.filter(n => n.type === type)
               return filteredNodes.length > 0 ? (

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import {
   ReactFlow,
   MiniMap,
@@ -14,34 +14,26 @@ import "@xyflow/react/dist/style.css";
 import { GORCNode } from "../../modules/GORCNodes";
 import { GORCLegend } from "./../Legend/GORCLegend";
 import "./Tree.css"
+import { useNodeSelection } from "../../contexts/SelectionContexts.ts";
 
 const nodeTypes = { gorc: GORCNodeView };
 
 export const Tree = () => {
   const treeManager = useTreeContext();
-  const [selectedNode, setSelectedNode] = useState<Node<GORCNode> | null>(null);
   const treeNodes = treeManager.getNodes();
-  const initialNodes = useMemo(() => {
-    return treeNodes.map((node) => ({
-      ...node,
-      data: {
-        ...node.data,
-        isSelected: selectedNode?.id === node.id,
-      },
-    }));
-  }, [treeNodes, selectedNode]);
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState(treeNodes);
   const edges = treeManager.getEdges();
+  const [selectedNode, setSelectedNode] = useNodeSelection();
 
   useEffect(() => {
-    setNodes(initialNodes);
-  }, [initialNodes, setNodes]);
+    setNodes(treeNodes);
+  }, [treeNodes, setNodes]);
 
   const onNodeClick = useCallback((_event: unknown, node: Node<GORCNode>) => {
-    setSelectedNode(node);
-  }, []);
+    setSelectedNode(node.data);
+  }, [setSelectedNode]);
 
-  const closePanel = () => setSelectedNode(null);
+  const closePanel = useCallback(() => setSelectedNode(null), [setSelectedNode]);
 
   return (
     <>
@@ -60,7 +52,7 @@ export const Tree = () => {
           <Controls />
         </ReactFlow>
         <GORCLegend />
-        <SidePanel node={selectedNode} onClose={closePanel} />
+        <SidePanel onClose={closePanel} />
       </div>
     </>
   );

--- a/src/contexts/SelectionContexts.ts
+++ b/src/contexts/SelectionContexts.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { RepositorySource } from "../modules/RepositorySource";
 import {
   BaseModel,
@@ -7,6 +7,7 @@ import {
 } from "../modules/LayeredModel";
 import { RepositoryManager } from "./RepositoryContext";
 import { useSettings, SettingsData } from "../contexts/SettingsContext";
+import { GORCNode } from "../modules/GORCNodes";
 
 type SelectionManager<T, S = T, D = null> = [
   S | D,
@@ -14,6 +15,10 @@ type SelectionManager<T, S = T, D = null> = [
   (selection: S) => void,
 ];
 type MultiSelectionManager<T> = SelectionManager<T, T[], T[]>;
+
+export const NodeSelectionManager = React.createContext<
+  SelectionManager<GORCNode, GORCNode | null>
+>([null, [], () => {console.log("Bad manager")}]);
 
 export const RepositorySelectionContext = React.createContext<
   SelectionManager<RepositorySource>
@@ -174,4 +179,22 @@ export function useModelSelectionManagers(
       (ss) => update({ sliceIds: new Set(ss.map((s) => s.id)) }),
     ],
   ];
+}
+
+export function useNodeSelectionManager() {
+  const [selectedNode, setSelectedNode] = React.useState<GORCNode | null>(null);
+  const selectionManager = React.useMemo<SelectionManager<GORCNode, GORCNode | null>>(() => {
+    return [
+      selectedNode,
+      [],
+      setSelectedNode
+    ]
+  }, [selectedNode, setSelectedNode]);
+  return selectionManager;
+}
+
+
+export function useNodeSelection(): [GORCNode | null, (selection: GORCNode | null) => void] {
+  const manager = useContext(NodeSelectionManager);
+  return [manager[0], manager[2]]
 }

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,15 @@ body {
 ul {
   padding-left: 1.5rem;
 }
+
+li {
+  margin: 0.5rem 0;
+}
+
+hr {
+  display: block;
+  height: 0.25rem;
+  background-color: var(--color-anti-flash-white-grey);
+  border: none;
+  margin: 1.5rem 0;
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -22,6 +22,8 @@ import {
   ModelSelectionContext,
   ProfileSelectionContext,
   SliceSelectionContext,
+  useNodeSelectionManager,
+  NodeSelectionManager,
 } from "../../contexts/SelectionContexts";
 import { useConfig } from "../../contexts/ConfigContext.ts";
 import "@xyflow/react/dist/style.css";
@@ -80,6 +82,7 @@ const Home = () => {
     [nodes, nodeSize]
   );
   const treeManager = useTreeManagerFromModelNodes(nodes, layout);
+  const nodeSelectionManager = useNodeSelectionManager();
   return (
     <RepositorySelectionContext.Provider value={repoSelection}>
       <ModelSelectionContext.Provider value={modelSelection}>
@@ -87,7 +90,9 @@ const Home = () => {
           <SliceSelectionContext.Provider value={sliceSelection}>
             <TreeContext.Provider value={treeManager}>
               <ModelContext.Provider value={modelDefintion}>
-                <HomeBase />
+                <NodeSelectionManager.Provider value={nodeSelectionManager}>
+                  <HomeBase />
+                </NodeSelectionManager.Provider>
               </ModelContext.Provider>
             </TreeContext.Provider>
           </SliceSelectionContext.Provider>


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related Issues

This PR closes #107 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)


## Changes
- List parent and child nodes in the overview of a selected node
- Allow navigation by clicking on related nodes
- Make current selection more visibile
- Add type indicator badge to related nodes

## Screenshot of the fix

<img width="2446" height="1970" alt="Screen Shot 2025-12-16 at 09 33 07" src="https://github.com/user-attachments/assets/f4db851b-c918-49be-b8c9-1bb8648c9931" />


## Testing

- Start the application
- Select a node and use the child and parent nodes to navigate

## Checklist
- [x] Code builds and runs
- [x] Tests have been added/updated
- [x] Documentation updated (if needed)

<!-- Optional: include screenshots, links, or any other context. -->
